### PR TITLE
Freedompraise/issue362

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,19 @@
+---
+name: Documentation Update
+about: Improve the documentation
+title: "docs"
+labels: "documentation"
+assignees: ""
+---
+
+## Documentation Update
+
+### What's the documentation idea?
+
+Which things do we need to add?
+
+### Record
+
+- [ ] I have read the Contributing Guidelines
+- [ ] I have searched the issues for a similar request
+- [ ] I want to work on this issue

--- a/.github/ISSUE_TEMPLATE/refactor_code.md
+++ b/.github/ISSUE_TEMPLATE/refactor_code.md
@@ -1,0 +1,25 @@
+---
+name: Refactor code
+about: Use this label to create code refactoring tasks.
+title: "[Refactor] <write what you want to add here>"
+labels: "refactor"
+assignees: ""
+---
+
+## Refactor Code
+
+### File Name
+
+Enter the path to the file that you want to refactor in the codebase
+
+for example: `django_project/blog/views.py`
+
+### Reason for refactoring
+
+Describe what improvements can be made in the codebase
+
+### Record
+
+- [ ] I have read the Contributing Guidelines
+- [ ] I have searched the issues for a similar request
+- [ ] I want to work on this issue

--- a/.github/ISSUE_TEMPLATE/style_change_request.md
+++ b/.github/ISSUE_TEMPLATE/style_change_request.md
@@ -1,0 +1,23 @@
+---
+name: Improve Styling
+about: Use this label for styling changes.
+title: "[Update] <write what you want to add here> [styling]"
+labels: "styling, enhancement"
+assignees: ""
+---
+
+## Styling Change Request
+
+### What's the style idea?
+
+Add descriptions
+
+### Screenshots
+
+Add screenshots
+
+### Record
+
+- [ ] I have read the Contributing Guidelines
+- [ ] I have searched the issues for a similar request
+- [ ] I want to work on this issue


### PR DESCRIPTION
# Add issue templates for different types of requests

This pull request adds three issue templates for the project's issue_template folder. The templates are:

- Refactor Code 🔧: This template is for code refactoring tasks. It asks the contributor to provide the file name, the reason for refactoring, and some checkboxes to record their agreement with the project's guidelines and code of conduct.
- Style Changing Request 👯‍♂️: This template is for style design suggestions. It asks the contributor to provide the style idea, screenshots, and some checkboxes to record their agreement with the project's guidelines and code of conduct.
- Documentation update 🔖: This template is for documentation improvement tasks. It asks the contributor to provide what's wrong with the documentation, screenshots, and some checkboxes to record their agreement with the project's guidelines and code of conduct.


These templates are written in Markdown format. They also follow GitHub's form schema syntax for creating web form fields.

The purpose of these templates is to standardize and simplify the process of creating issues for the project. They also help the contributors to provide relevant and complete information for each type of request.

I hope these templates are useful and meet expectations. Please let me know if you have any feedback or suggestions for improvement. Thank you for your time and attention.

is solves #362 
