### PR TITLE
Freedompraise/issue318

### DIFF
--- a/django_project/blog/templates/blog/post/post_detail.html
+++ b/django_project/blog/templates/blog/post/post_detail.html
@@ -125,7 +125,7 @@
         </div>
         <div class="related-post-text">
           <h3>{{ post.title }}</h3>
-          <p>{{ post.snippet|safe }}</p>
+          <p>{{ post.snippet|safe|truncatewords:10 }}</p>
         </div>
       </a>
     </li>

--- a/django_project/blog/templates/blog/post/post_detail.html
+++ b/django_project/blog/templates/blog/post/post_detail.html
@@ -112,4 +112,26 @@
 
 <!-- Create Comments Section-->
 {% include 'blog/comment/add_comment.html' %}
+
+<!-- Related Posts Section -->
+<section id="related-posts-section" class="content-section sml-margin-top-bottom">
+  <h2>Related Posts</h2>
+  <ul id="related-posts-list">
+    {% for post in related_posts %}
+    <li class="related-post">
+      <a href="{{ post.get_absolute_url }}">
+        <div class="related-post-image">
+          <img src="{{ post.metaimg.url }}" alt="{{ post.metaimg_alt_txt }}">
+        </div>
+        <div class="related-post-text">
+          <h3>{{ post.title }}</h3>
+          <p>{{ post.snippet|safe }}</p>
+        </div>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+
+
 {% endblock content %}

--- a/django_project/blog/views.py
+++ b/django_project/blog/views.py
@@ -316,10 +316,16 @@ class PostDetailView(DetailView):
         return Post.objects.filter(slug=self.kwargs["slug"])
 
     def get_context_data(self, **kwargs):
+        category = self.object.category
+        related_posts = Post.objects.filter(category=category).exclude(
+            slug=self.object.slug
+        )[:5]
+
         context = super().get_context_data(**kwargs)
         context["title"] = self.object.title
         context["description"] = self.object.metadesc
         context["comment_form"] = CommentForm()
+        context["related_posts"] = related_posts
         return context
 
 

--- a/django_project/blog/views.py
+++ b/django_project/blog/views.py
@@ -319,7 +319,7 @@ class PostDetailView(DetailView):
         category = self.object.category
         related_posts = Post.objects.filter(category=category).exclude(
             slug=self.object.slug
-        )[:5]
+        )[:3]
 
         context = super().get_context_data(**kwargs)
         context["title"] = self.object.title

--- a/django_project/staticfiles/css/main.css
+++ b/django_project/staticfiles/css/main.css
@@ -625,7 +625,7 @@ figure {
   fill: #0077b5;
 }
 .resp-sharing-button__link.x:hover {
-  background-color:#4D4D4D;
+  background-color: #4d4d4d;
 }
 .social-share-btn {
   width: 24px;
@@ -1458,4 +1458,73 @@ img {
 .comment-btn {
   padding: 3px 8px;
   font-size: 8px;
+}
+
+/* Container for the related posts section */
+#related-posts-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 20px;
+}
+
+/* Title for the related posts section */
+#related-posts-section h2 {
+  font-family: Arial, sans-serif;
+  font-size: 24px;
+  font-weight: bold;
+  color: #1da1f2;
+}
+
+/* List of related posts */
+#related-posts-list {
+  list-style: none;
+  padding: 0;
+}
+
+/* List item for each related post */
+.related-post {
+  display: flex;
+  align-items: center;
+  margin: 10px;
+}
+
+/* Image for each related post */
+.related-post img {
+  max-width: 100px;
+  max-height: 100px;
+}
+
+/* Text container for each related post */
+.related-post div {
+  display: flex;
+  flex-direction: column;
+  margin-left: 10px;
+  padding: 10px;
+}
+
+/* Title for each related post */
+.related-post h3 {
+  font-family: Arial, sans-serif;
+  font-size: 18px;
+  font-weight: normal;
+  color: black;
+}
+
+/* Snippet for each related post */
+.related-post p {
+  font-family: Arial, sans-serif;
+  font-size: 14px;
+  font-weight: normal;
+  color: gray;
+}
+
+/* Link for each related post */
+.related-post a {
+  text-decoration: none;
+}
+
+/* Hover effect for each related post */
+.related-post:hover {
+  background-color: #f0f8ff;
 }

--- a/django_project/staticfiles/css/main.css
+++ b/django_project/staticfiles/css/main.css
@@ -1464,16 +1464,13 @@ img {
 #related-posts-section {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: left;
   margin: 20px;
 }
 
-/* Title for the related posts section */
 #related-posts-section h2 {
-  font-family: Arial, sans-serif;
-  font-size: 24px;
-  font-weight: bold;
-  color: #1da1f2;
+  text-align: left;
+  align-self: flex-start;
 }
 
 /* List of related posts */


### PR DESCRIPTION
## Description

This PR solves issue #318. It matches related posts with the criteria of being under the same category, and displays 3 of them under a post. The related posts are displayed under each other, with their images and snippets truncated to a fitting size. The related posts section also has a header that is aligned to the left.


## Changes Made

- [x] Added new feature
- [ ] Fixed bug
- [ ] Refactored code
- [ ] Other (please describe):

## Test Plan

It passes the workflow tests

## Checklist

- [x] I have read the [contributing guidelines](link_to_contributing_guidelines)
- [x] I have added tests to cover my changes and they all pass in addition to the existing tests.
- [x] I have added documentation for my changes (if appropriate)

## Additional Information

I believe, there'll be a better solution to this, like:
- using django-taggit to filter the related posts by tags instead of categories. This way, we can show more specific and relevant posts to the readers, based on their interests and preferences. 
- We can also use a similarity algorithm or a machine learning model to rank the related posts by their relevance or popularity, instead of selecting them randomly.
Till then, this works well
