### PR TITLE
ci: mint App token for auto-merge when configured

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,17 @@ name: Auto Merge
 # Arm squash auto-merge for non-draft same-repo PRs from a human User who is
 # the repo owner or an org OWNER/MEMBER (you or an agent using your credentials).
 # Excludes Dependabot/bots/forks. Job-level gate → skipped events burn zero minutes.
+#
+# GITHUB_TOKEN merges do not create new workflow runs except workflow_dispatch
+# and repository_dispatch (Triggering a workflow):
+# https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+# When APP_PRIVATE_KEY + APP_CLIENT_ID (or APP_ID) are set, mint an App
+# installation token (~1h, own identity) so the land is a real push. If unset,
+# keep GITHUB_TOKEN --auto (do not fail). App --auto is primary;
+# GITHUB_TOKEN --auto is the no-secret fallback. Heroku GitHub auto-deploy from
+# `main` needs a real push (GITHUB_TOKEN merge as github-actions[bot]
+# suppresses the push event). REPO_AUTOMATION_TOKEN is a last-resort PAT,
+# not required.
 
 on:
   pull_request:
@@ -30,8 +41,30 @@ jobs:
         github.event.pull_request.author_association == 'MEMBER'
       )
     steps:
+      - name: Mint GitHub App token
+        id: app-token
+        if: ${{ secrets.APP_PRIVATE_KEY != '' && (vars.APP_CLIENT_ID != '' || secrets.APP_CLIENT_ID != '' || vars.APP_ID != '' || secrets.APP_ID != '') }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID || secrets.APP_CLIENT_ID }}
+          app-id: ${{ vars.APP_ID || secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Enable auto-merge for owner/member PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.REPO_AUTOMATION_TOKEN || secrets.GITHUB_TOKEN }}
+          HAS_APP_TOKEN: ${{ steps.app-token.outputs.token != '' }}
+          HAS_AUTOMATION_TOKEN: ${{ secrets.REPO_AUTOMATION_TOKEN != '' }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr merge --auto --squash --delete-branch --repo "$GITHUB_REPOSITORY" "$PR_NUMBER"
+        run: |
+          set -euo pipefail
+          if [ "$HAS_APP_TOKEN" = "true" ]; then
+            echo "Arming auto-merge with GitHub App installation token (not GITHUB_TOKEN → push fires)."
+          elif [ "$HAS_AUTOMATION_TOKEN" = "true" ]; then
+            echo "Arming auto-merge with REPO_AUTOMATION_TOKEN (last-resort PAT)."
+          else
+            echo "No App/PAT — arming GITHUB_TOKEN --auto (bot merge may skip push/CI on main)."
+          fi
+          gh pr merge --auto --squash --delete-branch --repo "$GITHUB_REPOSITORY" "$PR_NUMBER"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,6 +14,10 @@ name: Auto Merge
 # `main` needs a real push (GITHUB_TOKEN merge as github-actions[bot]
 # suppresses the push event). REPO_AUTOMATION_TOKEN is a last-resort PAT,
 # not required.
+#
+# Gate the mint step via job env (not `if: secrets.*`). GitHub does not expose
+# the secrets context on `jobs.<job_id>.steps.if`; mapping presence to env
+# keeps skip-not-fail when App credentials are unset and passes actionlint.
 
 on:
   pull_request:
@@ -40,11 +44,17 @@ jobs:
         github.event.pull_request.author_association == 'OWNER' ||
         github.event.pull_request.author_association == 'MEMBER'
       )
+    env:
+      HAS_APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY != '' }}
+      HAS_APP_CLIENT_ID: ${{ vars.APP_CLIENT_ID != '' || secrets.APP_CLIENT_ID != '' }}
+      HAS_APP_ID: ${{ vars.APP_ID != '' || secrets.APP_ID != '' }}
     steps:
       - name: Mint GitHub App token
         id: app-token
-        if: ${{ secrets.APP_PRIVATE_KEY != '' && (vars.APP_CLIENT_ID != '' || secrets.APP_CLIENT_ID != '' || vars.APP_ID != '' || secrets.APP_ID != '') }}
-        uses: actions/create-github-app-token@v3
+        if: ${{ env.HAS_APP_PRIVATE_KEY == 'true' && (env.HAS_APP_CLIENT_ID == 'true' || env.HAS_APP_ID == 'true') }}
+        # @v3 is the movable major; actionlint 1.7.12's bundled metadata omits
+        # client-id, so pin the v3.2.0 tag (same major) which loads real action.yml.
+        uses: actions/create-github-app-token@v3.2.0
         with:
           client-id: ${{ vars.APP_CLIENT_ID || secrets.APP_CLIENT_ID }}
           app-id: ${{ vars.APP_ID || secrets.APP_ID }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,8 +12,7 @@ name: Auto Merge
 # keep GITHUB_TOKEN --auto (do not fail). App --auto is primary;
 # GITHUB_TOKEN --auto is the no-secret fallback. Heroku GitHub auto-deploy from
 # `main` needs a real push (GITHUB_TOKEN merge as github-actions[bot]
-# suppresses the push event). REPO_AUTOMATION_TOKEN is a last-resort PAT,
-# not required.
+# suppresses the push event). No classic PAT required.
 #
 # Gate the mint step via job env (not `if: secrets.*`). GitHub does not expose
 # the secrets context on `jobs.<job_id>.steps.if`; mapping presence to env
@@ -64,17 +63,14 @@ jobs:
 
       - name: Enable auto-merge for owner/member PRs
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.REPO_AUTOMATION_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           HAS_APP_TOKEN: ${{ steps.app-token.outputs.token != '' }}
-          HAS_AUTOMATION_TOKEN: ${{ secrets.REPO_AUTOMATION_TOKEN != '' }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           if [ "$HAS_APP_TOKEN" = "true" ]; then
             echo "Arming auto-merge with GitHub App installation token (not GITHUB_TOKEN → push fires)."
-          elif [ "$HAS_AUTOMATION_TOKEN" = "true" ]; then
-            echo "Arming auto-merge with REPO_AUTOMATION_TOKEN (last-resort PAT)."
           else
-            echo "No App/PAT — arming GITHUB_TOKEN --auto (bot merge may skip push/CI on main)."
+            echo "No App credentials — arming GITHUB_TOKEN --auto (bot merge may skip push/CI on main)."
           fi
           gh pr merge --auto --squash --delete-branch --repo "$GITHUB_REPOSITORY" "$PR_NUMBER"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Port [asset-buyer PR #52](https://github.com/jsolly/asset-buyer/pull/52) App-token auto-merge into this repo’s `.github/workflows/auto-merge.yml` only.

`GITHUB_TOKEN` squash-merges land as `github-actions[bot]` and do not create new workflow runs (`push` is suppressed). That also skips Heroku GitHub auto-deploy from `main`. When a GitHub App is installed (`APP_PRIVATE_KEY` + `APP_CLIENT_ID` or `APP_ID`), this workflow mints an installation token so the land is a real push.

## Changes Made

- [x] Other (please describe): optional GitHub App token mint in `auto-merge.yml`
- If `secrets.APP_PRIVATE_KEY` and `vars`/`secrets` `APP_CLIENT_ID` (or `APP_ID`) are set, mint with `actions/create-github-app-token@v3.2.0` (`contents: write`, `pull-requests: write`) and `gh pr merge --auto --squash` with that token.
- If those App credentials are unset, keep `GITHUB_TOKEN --auto` and do not fail (mint step is skipped via job-env presence flags).
- No classic PAT required. Do not prefer `REPO_AUTOMATION_TOKEN` — a present-but-invalid PAT 401s and would block the `GITHUB_TOKEN` fallback.
- Do not invent credentials. `ci.yml` is unchanged.

Repo-specific adaptations vs asset-buyer #52 (this repo’s CI runs actionlint 1.7.12):

- Gate mint on job `env` `HAS_*` flags instead of `if: secrets.*` (`secrets` is not a valid `steps.if` context).
- Pin `create-github-app-token@v3.2.0` (v3 line) so actionlint loads `client-id` from the published `action.yml` instead of stale bundled metadata.
- Token chain is App installation token or `GITHUB_TOKEN` only.

## Test Plan

- [x] `yamllint -s .github/workflows/auto-merge.yml`
- [x] `npm run check:actions` (actionlint + shellcheck)
- [x] Structural pins: App mint inputs, `--auto --squash`, `GITHUB_TOKEN` fallback, no invented credentials, no PAT in the token chain
- GitHub `CI / ci` on this PR
- Auto-merge job: App creds unset in this repo → arm with `GITHUB_TOKEN`, must not 401

## Checklist

- [x] Change is limited to `.github/workflows/auto-merge.yml`
- [x] No credentials invented or committed
- [x] Unset App secrets still arm `GITHUB_TOKEN --auto`

## Additional Information

Source: jsolly/asset-buyer#52. Comments adapted for heroku-git (this repo has no `ensure-main-ci.yml` / `ci.yml` `merge-pr`). After merge, installing the App (`APP_PRIVATE_KEY` + `APP_CLIENT_ID`) makes subsequent merges real pushes so CI and Heroku deploy from `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b87ef06-5b51-4331-a68b-b98b53ed1625?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b87ef06-5b51-4331-a68b-b98b53ed1625&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

