### PR TITLE
fix(cursor): install cloud skills from private dotagents

### DIFF
--- a/.cursor/CLOUD.md
+++ b/.cursor/CLOUD.md
@@ -3,39 +3,43 @@
 This file is read by Cloud / Background Agents only (local IDE chat ignores it).
 Repo `AGENTS.md` still applies first; this file overlays cloud-specific facts.
 
-## Public agent-skills package (mirror)
+## Skills package (private checkout)
 
-`.cursor/install-cloud-skills.sh` (via `.cursor/environment.json` `install`) shallow-clones
-<https://github.com/jsolly/agent-skills> and installs the **full published package**:
+`.cursor/install-cloud-skills.sh` (via `.cursor/environment.json` `install`) copies
+**skills, agents, and cited rules** from a private `dotagents` checkout into VM
+home paths. Preferred source is a host-local tree (`DOTAGENTS_ROOT`, or this
+repo when the installer is running from it). If none is present it may shallow-
+clone `jsolly/dotagents`. There is no public skills mirror.
 
 | Artifact | VM path | Notes |
 | --- | --- | --- |
 | Skills | `~/.cursor/skills/` | Same discovery as laptop `~/.cursor/skills` |
 | Agents | `~/.cursor/agents/` | One `.md` file per reviewer/scanner agent |
-| Cited rules | `~/.cursor/agent-skills-package/rules/` | **Read from here** when a skill cites `rules/<name>.md` |
+| Cited rules | `~/.cursor/dotagents-package/rules/` | **Read from here** when a skill cites `rules/<name>.md` |
 
-Source is the sanitized public mirror — **not** private `~/code/dotagents`.
+Laptop-only skills (see `skills/laptop-only.txt`) are **not** installed on cloud.
 
-There is **no** `~/code/dotagents` on this VM. Do not look for it or claim child repos inherit it.
-Do **not** vendor the private dotagents tree into this repo.
+There is **no** `~/code/dotagents` on this VM unless the current repo *is*
+dotagents. Do not look for a laptop home wiring path or claim child repos inherit
+it. Do **not** vendor the private dotagents tree into this repo.
 
 `~/.cursor/rules` from a laptop home is **not** auto-applied on cloud. User Rules + repo
 `AGENTS.md` + this file carry policy; skills that cite rules must read the copies under
-`~/.cursor/agent-skills-package/rules/`.
+`~/.cursor/dotagents-package/rules/`.
 
 ## Laptop-only (not on cloud)
 
-- `scripts/install-local-agent-runtime.sh` and `scripts/doctor-agents.sh`
+- `setup/install-local-agent-runtime.sh` and `setup/doctor-agents.sh`
 - User-level `~/.cursor/hooks.json` and other home hooks/guards
-- Private skills (e.g. `verify-ui`, `publish-skills`, family-memory)
+- Laptop-only skills (e.g. `setup-personal-machine`, `create-lambda`)
 
 ## Skills / slash commands
 
 If slash-skill autocomplete is empty on a **follow-up** turn, invoke the skill by name in prose
 (known Agents Window bug; typed invoke still works).
 
-Private laptop-only skills are **not** available here. For UI smoke, follow this repo's
-`AGENTS.md` **Local UI verification** stanza — do not invent `/verify-ui` when that skill is absent.
+`/verify-ui` ships in this package — use it for UI smoke when the skill is present. If it is
+missing, follow this repo's `AGENTS.md` **Local UI verification** stanza instead.
 
 ## Hooks / guards
 

--- a/.cursor/install-cloud-skills.sh
+++ b/.cursor/install-cloud-skills.sh
@@ -1,35 +1,145 @@
 #!/usr/bin/env bash
-# Install the full public jsolly/agent-skills package into Cursor Cloud Agent home paths.
-# Skills → ~/.cursor/skills; agents → ~/.cursor/agents; cited rules → ~/.cursor/agent-skills-package/rules
+# Install skills, agents, and cited rules from a private dotagents checkout into
+# Cursor Cloud Agent home paths.
+# Skills → ~/.cursor/skills; agents → ~/.cursor/agents;
+# cited rules → ~/.cursor/dotagents-package/rules
 # Idempotent: safe to re-run from environment.json install/update.
+#
+# Source (first match):
+#   1. $DOTAGENTS_ROOT if it looks like this repo
+#   2. The checkout that contains this script, if it looks like this repo
+#      (templates/cloud-agent/ or a .cursor/ copy inside dotagents itself)
+#   3. $HOME/code/dotagents if present
+#   4. Shallow clone of this private repo ($DOTAGENTS_CLONE_URL, default
+#      https://github.com/jsolly/dotagents.git)
+# Never clones a public skills mirror. Does not vendor the full private tree
+# into the child repo working tree — copies only into VM home paths.
+# Laptop-only skills stay off cloud VMs (skills/laptop-only.txt).
+# skills/work-excluded.txt is a same-name alias for already-copied child installers.
 set -euo pipefail
 
 SKILLS_HOME="${CURSOR_CLOUD_SKILLS_HOME:-${HOME}/.cursor/skills}"
 AGENTS_HOME="${CURSOR_CLOUD_AGENTS_HOME:-${HOME}/.cursor/agents}"
-RULES_HOME="${CURSOR_CLOUD_PACKAGE_RULES:-${HOME}/.cursor/agent-skills-package/rules}"
-MIRROR_URL="${AGENT_SKILLS_MIRROR_URL:-https://github.com/jsolly/agent-skills.git}"
-MIRROR_REF="${AGENT_SKILLS_MIRROR_REF:-main}"
+RULES_HOME="${CURSOR_CLOUD_PACKAGE_RULES:-${HOME}/.cursor/dotagents-package/rules}"
 
-tmpdir="$(mktemp -d)"
-cleanup() { rm -rf "$tmpdir"; }
+looks_like_dotagents() {
+  local root="$1"
+  [[ -n "$root" && -d "$root/skills" && -d "$root/agents" && -d "$root/rules" ]] || return 1
+  local f
+  shopt -s nullglob
+  for f in "$root/skills"/*/SKILL.md; do
+    shopt -u nullglob
+    [[ -f "$f" ]] && return 0
+  done
+  shopt -u nullglob
+  return 1
+}
+
+append_skip_names() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  local line
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" ]] && continue
+    LAPTOP_ONLY+=("$line")
+  done < "$file"
+}
+
+read_laptop_only() {
+  local root="$1"
+  LAPTOP_ONLY=()
+  append_skip_names "$root/skills/laptop-only.txt"
+  # Alias: already-copied child-repo installers still read work-excluded.txt
+  # from a clone of this repo. Union so either filename skips the same skills.
+  append_skip_names "$root/skills/work-excluded.txt"
+}
+
+is_laptop_only() {
+  local name="$1" x
+  for x in "${LAPTOP_ONLY[@]+"${LAPTOP_ONLY[@]}"}"; do
+    [[ "$x" == "$name" ]] && return 0
+  done
+  return 1
+}
+
+clone_tmp=""
+cleanup() {
+  if [[ -n "$clone_tmp" ]]; then
+    rm -rf "$clone_tmp"
+  fi
+}
 trap cleanup EXIT
 
-echo "cloud-package: cloning ${MIRROR_URL}@${MIRROR_REF} (shallow)"
-git clone --depth 1 --branch "$MIRROR_REF" "$MIRROR_URL" "$tmpdir/agent-skills"
-root="$tmpdir/agent-skills"
+resolve_root() {
+  local script_dir repo
+  if looks_like_dotagents "${DOTAGENTS_ROOT:-}"; then
+    printf '%s\n' "$(cd "$DOTAGENTS_ROOT" && pwd)"
+    return 0
+  fi
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # templates/cloud-agent/install-cloud-skills.sh → repo root
+  repo="$(cd "$script_dir/../.." && pwd)"
+  if looks_like_dotagents "$repo"; then
+    printf '%s\n' "$repo"
+    return 0
+  fi
+  # .cursor/install-cloud-skills.sh inside a dotagents checkout
+  repo="$(cd "$script_dir/.." && pwd)"
+  if looks_like_dotagents "$repo"; then
+    printf '%s\n' "$repo"
+    return 0
+  fi
+  if looks_like_dotagents "${HOME}/code/dotagents"; then
+    printf '%s\n' "$(cd "${HOME}/code/dotagents" && pwd)"
+    return 0
+  fi
+  return 1
+}
+
+root=""
+if root="$(resolve_root)"; then
+  echo "cloud-package: using local checkout $root"
+else
+  clone_url="${DOTAGENTS_CLONE_URL:-https://github.com/jsolly/dotagents.git}"
+  clone_ref="${DOTAGENTS_CLONE_REF:-main}"
+  clone_tmp="$(mktemp -d)"
+  echo "cloud-package: no local checkout; cloning ${clone_url}@${clone_ref} (shallow, sparse)"
+  if ! git clone --depth 1 --filter=blob:none --sparse --branch "$clone_ref" \
+    "$clone_url" "$clone_tmp/dotagents"; then
+    echo "cloud-package: ERROR — set DOTAGENTS_ROOT to a host-local checkout of the private dotagents repo (laptop: ~/code/dotagents)." >&2
+    exit 1
+  fi
+  git -C "$clone_tmp/dotagents" sparse-checkout set skills agents rules
+  root="$clone_tmp/dotagents"
+  if ! looks_like_dotagents "$root"; then
+    echo "cloud-package: ERROR — clone at $root is not a dotagents checkout" >&2
+    exit 1
+  fi
+fi
+
+read_laptop_only "$root"
 
 # --- skills (required) ---
 src_skills="$root/skills"
 if [[ ! -d "$src_skills" ]]; then
-  echo "cloud-package: ERROR — no skills/ directory in mirror checkout" >&2
+  echo "cloud-package: ERROR — no skills/ directory in checkout $root" >&2
   exit 1
 fi
 
 mkdir -p "$SKILLS_HOME"
 installed_skills=0
+skipped_excluded=0
 for skill_dir in "$src_skills"/*/; do
   [[ -d "$skill_dir" ]] || continue
   name="$(basename "$skill_dir")"
+  if is_laptop_only "$name"; then
+    echo "cloud-package: skip skill ${name} (laptop-only)"
+    skipped_excluded=$((skipped_excluded + 1))
+    continue
+  fi
   if [[ ! -f "$skill_dir/SKILL.md" ]]; then
     echo "cloud-package: skip skill ${name} (no SKILL.md)"
     continue
@@ -42,50 +152,52 @@ for skill_dir in "$src_skills"/*/; do
 done
 
 if [[ "$installed_skills" -eq 0 ]]; then
-  echo "cloud-package: ERROR — no skills installed from mirror" >&2
+  echo "cloud-package: ERROR — no skills installed from $root" >&2
   exit 1
 fi
 
-# --- agents (optional during mirror transition) ---
+# --- agents ---
 src_agents="$root/agents"
 installed_agents=0
 if [[ ! -d "$src_agents" ]]; then
-  echo "cloud-package: WARN — no agents/ in mirror; skills only (republish with /publish-skills)" >&2
-else
-  mkdir -p "$AGENTS_HOME"
-  shopt -s nullglob
-  for agent_file in "$src_agents"/*.md; do
-    name="$(basename "$agent_file")"
-    dest="$AGENTS_HOME/$name"
-    cp -f "$agent_file" "$dest"
-    installed_agents=$((installed_agents + 1))
-    echo "cloud-package: installed agent ${name} → ${dest}"
-  done
-  shopt -u nullglob
-  if [[ "$installed_agents" -eq 0 ]]; then
-    echo "cloud-package: WARN — agents/ present but empty; continuing with skills only" >&2
-  fi
+  echo "cloud-package: ERROR — no agents/ in checkout $root" >&2
+  exit 1
+fi
+mkdir -p "$AGENTS_HOME"
+shopt -s nullglob
+for agent_file in "$src_agents"/*.md; do
+  name="$(basename "$agent_file")"
+  dest="$AGENTS_HOME/$name"
+  cp -f "$agent_file" "$dest"
+  installed_agents=$((installed_agents + 1))
+  echo "cloud-package: installed agent ${name} → ${dest}"
+done
+shopt -u nullglob
+if [[ "$installed_agents" -eq 0 ]]; then
+  echo "cloud-package: ERROR — agents/ present but empty at $src_agents" >&2
+  exit 1
 fi
 
-# --- cited rules (optional during mirror transition) ---
+# --- cited rules ---
 src_rules="$root/rules"
 installed_rules=0
 if [[ ! -d "$src_rules" ]]; then
-  echo "cloud-package: WARN — no rules/ in mirror; read cited rules from republished package later" >&2
-else
-  mkdir -p "$RULES_HOME"
-  shopt -s nullglob
-  for rule_file in "$src_rules"/*.md; do
-    name="$(basename "$rule_file")"
-    dest="$RULES_HOME/$name"
-    cp -f "$rule_file" "$dest"
-    installed_rules=$((installed_rules + 1))
-    echo "cloud-package: installed rule ${name} → ${dest}"
-  done
-  shopt -u nullglob
-  if [[ "$installed_rules" -eq 0 ]]; then
-    echo "cloud-package: WARN — rules/ present but empty; continuing with skills only" >&2
-  fi
+  echo "cloud-package: ERROR — no rules/ in checkout $root" >&2
+  exit 1
+fi
+mkdir -p "$RULES_HOME"
+shopt -s nullglob
+for rule_file in "$src_rules"/*.md; do
+  name="$(basename "$rule_file")"
+  dest="$RULES_HOME/$name"
+  cp -f "$rule_file" "$dest"
+  installed_rules=$((installed_rules + 1))
+  echo "cloud-package: installed rule ${name} → ${dest}"
+done
+shopt -u nullglob
+if [[ "$installed_rules" -eq 0 ]]; then
+  echo "cloud-package: ERROR — rules/ present but empty at $src_rules" >&2
+  exit 1
 fi
 
-echo "cloud-package: done (${installed_skills} skill(s), ${installed_agents} agent file(s), ${installed_rules} rule file(s))"
+echo "cloud-package: done (${installed_skills} skill(s), ${skipped_excluded} laptop-only skipped, ${installed_agents} agent file(s), ${installed_rules} rule file(s))"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

John deleted the public GitHub mirror `jsolly/agent-skills`. This repo still cloned it from `.cursor/install-cloud-skills.sh`.

This copies the current cloud-agent template from private `jsolly/dotagents` (`main`, `templates/cloud-agent/`) into `.cursor/`:

- Replace `.cursor/install-cloud-skills.sh` with `templates/cloud-agent/install-cloud-skills.sh` (byte-identical; git blob `3e75e60ba4829e72c9efb57c23b6a396e8ae9710`)
- Replace the public-mirror stanza in `.cursor/CLOUD.md` with `templates/cloud-agent/CLOUD.md` (byte-identical; git blob `8f80fc0111dc63192e2e8a48874368dad5e9e314`). Extra sections this file already had (Laptop-only, Skills/slash commands, Hooks/guards, AWS reads) remain because they are part of the current template.
- Keep `.cursor/environment.json` `install` calling `bash .cursor/install-cloud-skills.sh`

Source is a private `dotagents` checkout (`DOTAGENTS_ROOT` / host-local, optional clone of `jsolly/dotagents`). Cited rules live at `~/.cursor/dotagents-package/rules/`. This change does not clone `jsolly/agent-skills` and does not vendor the private tree into this repo.

Repo-wide grep is clean for `jsolly/agent-skills`, `AGENT_SKILLS_MIRROR`, `agent-skills-package`, and `sanitized public mirror`. App code is unchanged.

## Changes Made

- [ ] Added new feature
- [ ] Fixed bug
- [ ] Refactored code
- [x] Other (please describe): Cloud Agent skills installer now reads private `dotagents` instead of the retired public mirror

## Test Plan

- Built a fake `DOTAGENTS_ROOT` with `ship`, laptop-only `setup-personal-machine`, `work-excluded.txt` `janitor`, plus agents/rules. Installer copied `ship`, skipped the excluded skills, wrote agents and cited rules, and did not vendor `skills/` / `agents/` / `rules/` into this repo.
- Clone fallback via `DOTAGENTS_CLONE_URL=file://…` installed from a local git repo.
- Pointing `DOTAGENTS_CLONE_URL` at `https://github.com/jsolly/agent-skills.git` fail-closes (exit 1).
- `markdownlint-cli2` on `.cursor/CLOUD.md`: 0 issues. `shellcheck` on the installer: clean.
- Django pytest not re-run: no app/test changes, and this VM has Python 3.12 (repo pin is 3.14).

## Screenshots (if appropriate)

Not a UI change. Installer proof is in the agent walkthrough log.

## Checklist

- [x] I have read the [contributing guidelines](docs/CONTRIBUTING.md)
- [ ] I have added tests to cover my changes and they all pass in addition to the existing tests.
- [x] I have added documentation for my changes (if appropriate)

## Additional Information

Do not merge this PR from the agent run. GitHub App / environment tokens for this child repo cannot clone private `jsolly/dotagents`; Cloud Agent `install` will use `DOTAGENTS_ROOT` when that checkout is attached, or clone `jsolly/dotagents` when credentials can read it.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7d31604-7585-464d-b0b3-5ffe6d123805?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7d31604-7585-464d-b0b3-5ffe6d123805&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

