### PR TITLE
Load portable Todoist handoffs in cloud agents

### DIFF
--- a/.cursor/CLOUD.md
+++ b/.cursor/CLOUD.md
@@ -16,6 +16,7 @@ clone `jsolly/dotagents`. There is no public skills mirror.
 | Skills | `~/.cursor/skills/` | Same discovery as laptop `~/.cursor/skills` |
 | Agents | `~/.cursor/agents/` | One `.md` file per reviewer/scanner agent |
 | Cited rules | `~/.cursor/dotagents-package/rules/` | **Read from here** when a skill cites `rules/<name>.md` |
+| Connector catalog | `~/.cursor/dotagents-package/mcps/catalog.json` | Canonical connector expectations; verify runtime authentication separately |
 
 Laptop-only skills (see `skills/laptop-only.txt`) are **not** installed on cloud.
 
@@ -26,6 +27,26 @@ it. Do **not** vendor the private dotagents tree into this repo.
 `~/.cursor/rules` from a laptop home is **not** auto-applied on cloud. User Rules + repo
 `AGENTS.md` + this file carry policy; skills that cite rules must read the copies under
 `~/.cursor/dotagents-package/rules/`.
+
+## Durable planning and human handoffs
+
+When this harness lacks a usable native planning mode, load
+`~/.cursor/skills/persist-todos-in-todoist/SKILL.md` for durable Todoist outcomes,
+cooperative claims and human handoffs. Human actions and ad hoc work outside a
+repo also use that skill. A supported native repo plan needs no Todoist mirror;
+reconsider this integration when Cursor Cloud or Grok Bot gains native planning.
+Reconcile already-tracked commitments regardless of the current harness.
+
+For Todoist-backed work, load the expected John user ID and email from the
+installed private persistence skill. Require both user-info fields to match
+before queue pickup or writes; missing private identity policy or an account
+mismatch stops Todoist work and is reported. Then read a known shared task and
+all its comments;
+shared-task visibility alone is not identity proof. Discover only work in this repo or assigned
+role, inside existing authorization. Missing tracker access blocks unattended
+Todoist pickup; explicitly requested read-only analysis may continue with an
+honest unsynced status. Native repo plans without a Todoist obligation do not
+require the connector. Catalog installation is not authentication proof.
 
 ## Laptop-only (not on cloud)
 

--- a/.cursor/install-cloud-skills.sh
+++ b/.cursor/install-cloud-skills.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Install skills, agents, and cited rules from a private dotagents checkout into
-# Cursor Cloud Agent home paths.
+# Install skills, agents, cited rules, and the connector/plugin catalog from a private dotagents
+# checkout into Cursor Cloud Agent home paths.
 # Skills → ~/.cursor/skills; agents → ~/.cursor/agents;
-# cited rules → ~/.cursor/dotagents-package/rules
+# cited rules → ~/.cursor/dotagents-package/rules;
+# mcps/catalog.json → ~/.cursor/dotagents-package/mcps (so /integration-verify can reconcile live
+# connectors/plugins against the canon on a VM with no laptop checkout)
 # Idempotent: safe to re-run from environment.json install/update.
 #
 # Source (first match):
@@ -21,6 +23,7 @@ set -euo pipefail
 SKILLS_HOME="${CURSOR_CLOUD_SKILLS_HOME:-${HOME}/.cursor/skills}"
 AGENTS_HOME="${CURSOR_CLOUD_AGENTS_HOME:-${HOME}/.cursor/agents}"
 RULES_HOME="${CURSOR_CLOUD_PACKAGE_RULES:-${HOME}/.cursor/dotagents-package/rules}"
+MCPS_HOME="${CURSOR_CLOUD_PACKAGE_MCPS:-${HOME}/.cursor/dotagents-package/mcps}"
 
 looks_like_dotagents() {
   local root="$1"
@@ -112,7 +115,7 @@ else
     echo "cloud-package: ERROR — set DOTAGENTS_ROOT to a host-local checkout of the private dotagents repo (laptop: ~/code/dotagents)." >&2
     exit 1
   fi
-  git -C "$clone_tmp/dotagents" sparse-checkout set skills agents rules
+  git -C "$clone_tmp/dotagents" sparse-checkout set skills agents rules mcps
   root="$clone_tmp/dotagents"
   if ! looks_like_dotagents "$root"; then
     echo "cloud-package: ERROR — clone at $root is not a dotagents checkout" >&2
@@ -200,4 +203,25 @@ if [[ "$installed_rules" -eq 0 ]]; then
   exit 1
 fi
 
-echo "cloud-package: done (${installed_skills} skill(s), ${skipped_excluded} laptop-only skipped, ${installed_agents} agent file(s), ${installed_rules} rule file(s))"
+# --- connector/plugin catalog ---
+# The cloud-first canon for MCP servers and marketplace plugins. Copied (not required) so an older
+# checkout still installs skills — a missing catalog degrades /integration-verify's reconciliation to
+# "canon unavailable", which the receipt discloses rather than inventing green.
+installed_catalog=0
+src_catalog="$root/mcps/catalog.json"
+if [[ -f "$src_catalog" ]]; then
+  mkdir -p "$MCPS_HOME"
+  cp -f "$src_catalog" "$MCPS_HOME/catalog.json"
+  installed_catalog=1
+  echo "cloud-package: installed connector catalog → ${MCPS_HOME}/catalog.json"
+  if [[ -f "$root/mcps/README.md" ]]; then
+    cp -f "$root/mcps/README.md" "$MCPS_HOME/README.md"
+  fi
+else
+  # These two files are installer-owned. An older checkout must not leave a
+  # previous revision looking like current canon to integration-verify.
+  rm -f "$MCPS_HOME/catalog.json" "$MCPS_HOME/README.md"
+  echo "cloud-package: WARN — no mcps/catalog.json in $root; /integration-verify cannot reconcile connectors against the canon" >&2
+fi
+
+echo "cloud-package: done (${installed_skills} skill(s), ${skipped_excluded} laptop-only skipped, ${installed_agents} agent file(s), ${installed_rules} rule file(s), ${installed_catalog} catalog file(s))"


### PR DESCRIPTION
Cloud agents now load the private Todoist policy when work needs durable fallback planning, human actions, ad hoc tracking, or reconciliation of an existing commitment. Native repo plans need no Todoist mirror, and the guidance calls for reassessment when Grok Bot or Cursor Cloud gains planning support.

Refresh the canonical installer to distribute the connector catalog with skills/references, and invalidate only installer-owned stale catalog files when the source has no catalog. Preserve the repository's existing runtime and AWS configuration. Expected account identity is read from the private skill rather than published here.

Validation: full normal local gate on Node 24; independent full review; canonical installer syntax and byte comparison; canonical 24-case installer regression including fresh sparse clone and stale-catalog preservation. Real Cursor Cloud execution verification remains queued until John's usage reset and resumption of existing runs; no replacement agents were launched.
