### PR TITLE
fix(static): publish versioned repository assets to CloudFront

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -358,6 +358,8 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
+
 if USE_CLOUD:
     AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
     AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
@@ -399,8 +401,6 @@ else:
     MEDIA_LOCATION = "mediafiles"
     MEDIA_URL = f"{STATIC_HOST}/mediafiles/"
     MEDIA_ROOT = os.path.join(BASE_DIR, "mediafiles")
-
-    STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 
     STORAGES = {
         "default": {

--- a/app/settings.py
+++ b/app/settings.py
@@ -591,7 +591,7 @@ CKEDITOR_5_CONFIGS = {
     },
 }
 
-CKEDITOR_5_CUSTOM_CSS = f"{STATIC_URL}django_ckeditor_5/ckeditor_custom.css"
+CKEDITOR_5_CUSTOM_CSS = "django_ckeditor_5/ckeditor_custom.css"
 
 # Make sure APPEND_SLASH is set
 APPEND_SLASH = True

--- a/app/storage_backends.py
+++ b/app/storage_backends.py
@@ -1,27 +1,24 @@
 import logging
+from urllib.parse import urlsplit
 
 from django.conf import settings
+from django.contrib.staticfiles.storage import ManifestFilesMixin
 from django.core.files.storage import FileSystemStorage
 from storages.backends.s3boto3 import S3Boto3Storage
 
 logger = logging.getLogger(__name__)
 
 
-class StaticStorage(S3Boto3Storage):
+class StaticStorage(ManifestFilesMixin, S3Boto3Storage):
     location = "static"
     default_acl = "public-read"
     file_overwrite = True
 
-    def url(self, name):
-        """Override url method to use CloudFront domain"""
-        logger.debug(f"StaticStorage.url called for {name}")
+    def __init__(self, *args, **kwargs):
+        # Let Django resolve the content-hashed filename before S3 builds the URL.
         if settings.USE_CLOUD and settings.STATIC_HOST:
-            url = f"{settings.STATIC_HOST}/{self.location}/{name}"
-            logger.debug(f"Returning CloudFront URL: {url}")
-            return url
-        url = super().url(name)
-        logger.debug(f"Returning S3 URL: {url}")
-        return url
+            kwargs.setdefault("custom_domain", urlsplit(settings.STATIC_HOST).netloc)
+        super().__init__(*args, **kwargs)
 
 
 class PublicMediaStorage(S3Boto3Storage):
@@ -83,4 +80,3 @@ class PostImageStorageLocal(PostImageStorageBase, FileSystemStorage):
     def _save(self, name, content):
         name = self.get_upload_path(name)
         return super()._save(name, content)
-

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,32 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from app.storage_backends import StaticStorage
+from tests.base import SetUp
+
+
+class CloudStaticStorageTests(SetUp):
+    def test_cloud_configuration_discovers_repository_stylesheet(self):
+        result = subprocess.run(
+            [sys.executable, "-c", "import json; from app import settings; print(json.dumps(settings.STATICFILES_DIRS))"],
+            env={**os.environ, "USE_CLOUD": "True", "LOGGING": "False"},
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        directories = json.loads(result.stdout)
+        self.assertTrue(any((Path(directory) / "css/main.css").is_file() for directory in directories))
+
+    @override_settings(DEBUG=False, USE_CLOUD=True, STATIC_HOST="https://cdn.example.com")
+    def test_cloud_static_url_uses_manifest_filename(self):
+        with patch.object(StaticStorage, "load_manifest", return_value=({"css/main.css": "css/main.abc123.css"}, "manifest-hash")):
+            storage = StaticStorage(bucket_name="example", access_key="test", secret_key="test")
+        self.assertEqual(storage.url("css/main.css"), "https://cdn.example.com/static/css/main.abc123.css")
+        with self.assertRaisesMessage(ValueError, "Missing staticfiles manifest entry"):
+            storage.url("css/missing.css")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from django.test import override_settings
+from django_ckeditor_5.widgets import CKEditor5Widget
 
 from app.storage_backends import StaticStorage
 from tests.base import SetUp
@@ -30,3 +31,15 @@ class CloudStaticStorageTests(SetUp):
         self.assertEqual(storage.url("css/main.css"), "https://cdn.example.com/static/css/main.abc123.css")
         with self.assertRaisesMessage(ValueError, "Missing staticfiles manifest entry"):
             storage.url("css/missing.css")
+
+    @override_settings(DEBUG=False, USE_CLOUD=True, STATIC_HOST="https://cdn.example.com")
+    def test_editor_media_resolves_custom_stylesheet_through_manifest(self):
+        manifest = {
+            "django_ckeditor_5/dist/styles.css": "django_ckeditor_5/dist/styles.abc123.css",
+            "django_ckeditor_5/ckeditor_custom.css": "django_ckeditor_5/ckeditor_custom.def456.css",
+        }
+        with patch.object(StaticStorage, "load_manifest", return_value=(manifest, "manifest-hash")):
+            storage = StaticStorage(bucket_name="example", access_key="test", secret_key="test")
+        with patch("django.contrib.staticfiles.storage.staticfiles_storage", storage):
+            css = "".join(CKEditor5Widget().media.render_css())
+        self.assertIn("https://cdn.example.com/static/django_ckeditor_5/ckeditor_custom.def456.css", css)


### PR DESCRIPTION
Production article templates deployed while the main stylesheet remained at its July 2025 version: cloud settings omitted the repository static directory, and static URLs reused unversioned CDN paths.

Collect repository static assets in both storage modes and use Django's manifest hashing with the configured CloudFront domain for S3 static URLs. New deployments reference content-specific filenames. Media storage remains unchanged.

Validation: full pinned local gate passed (128 tests, 9 warnings, no test skips); regression tests cover cloud discovery of main.css, manifest URL resolution, and missing-manifest failure. CKEditor custom CSS also resolves through the manifest, with actual widget-media regression coverage. Prior SEO changes in #630 passed desktop/mobile comment interactions and local Lighthouse 98/100/100/100. Live hashed CSS and production Lighthouse will be checked after deployment.
