### PR TITLE
fix: validate tooling and actual Python dependency pins

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -52,6 +52,10 @@ else
   exit 1
 fi
 
+# Validate the actual environment before trusting a borrowed or existing venv.
+run_step "Python runtime + dependency pins" python3 scripts/check-python-pins.py
+run_step "Python dependency compatibility" python3 -m pip check
+
 # Test-only Django settings (mirror the old workflow env).
 export DEBUG=False
 export LOGGING=False

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,3 +119,5 @@ Auth-gated admin/authoring UI (public blog pages need no login). Follow `rules/f
 - **Dev server:** with `.venv` activated — `python manage.py runserver` → <http://127.0.0.1:8000>
 - **Sign-in:** Django auth with `DEFAULT_USER` and `DEFAULT_PASSWORD` from `.env.local` (see `.env.example`). Keep these in sync with seeded accounts (local defaults: `admin` / `admin` after seed/setup).
 - **Do not** invent credentials or commit `.env.local`.
+
+The pre-commit gate verifies the active Python minor version and installed package versions against `.python-version` and `requirements.txt`, including when it borrows the primary checkout's `.venv`. Matching requirements files alone do not prove the environment is current. Drift fails before tests; refresh the active environment with `python -m pip install -r requirements.txt`.

--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ ruff format app
 
 ### Pre-push gate
 
-The quality gate (ruff, collectstatic, migrate, pytest + coverage) runs locally on every push to `main` via the tracked pre-push hook. Wire it up once per clone:
+The quality gate (ruff, collectstatic, migrate, pytest + coverage) runs locally on every commit via the tracked pre-commit hook. Wire it up once per clone:
 
 ```shell
 git config core.hooksPath .git-hooks
 ```
 
-The gate logic lives in `.git-hooks/pre-push`; a failure aborts the push.
+The gate logic lives in `.git-hooks/pre-commit`; a failure aborts the commit.
 
 ### Live Reload
 
@@ -131,7 +131,7 @@ python3 manage.py livereload
 - HTMX for dynamic page updates without a page refresh
 - Robots.txt, security.txt, and sitemap.xml for optimized SEO and security
 - Git hooks for automatic static file generation (manage.py collectstatic)
-- Local pre-push quality gate (lint, collectstatic, migrations, tests + coverage) via `.git-hooks/pre-push`. Push with confidence!
+- Local pre-commit quality gate (lint, collectstatic, migrations, tests + coverage) via `.git-hooks/pre-commit`. Push with confidence!
 - Compatible with Sqllite or postgres databases for fast protyping and production
 - Deploy static assets to Amazon S3 + Cloudfront just by changing a few settings in the .env.local file.
 - Procfile included for easy deployment with Heroku or other services that use Procfile.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,7 @@
 			"devDependencies": {
 				"github-actionlint": "^1.7.12",
 				"heroku": "^11.10.0",
-				"markdownlint-cli2": "0.23.2",
-				"shellcheck": "^4.1.0"
+				"markdownlint-cli2": "0.23.2"
 			},
 			"engines": {
 				"node": "24.x"
@@ -42,33 +41,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/@borewit/text-codec": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
-			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
-		"node_modules/@felipecrs/decompress-tarxz": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@felipecrs/decompress-tarxz/-/decompress-tarxz-5.0.4.tgz",
-			"integrity": "sha512-a+nAnDsiUA84Sy/a+FKYJtjOjFvNtW8Jcbi3NwE8kJKPpYAxINFLYsC9mev9/wngiNEBA3jfHn0qNFwICeZNJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@xhmikosr/decompress-tar": "^8.1.0",
-				"file-type": "^20.5.0",
-				"is-stream": "^2.0.1",
-				"xz-decompress": "^0.2.3"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
 		"node_modules/@heroku-cli/command": {
 			"version": "13.2.0",
 			"resolved": "https://registry.npmjs.org/@heroku-cli/command/-/command-13.2.0.tgz",
@@ -91,6 +63,16 @@
 			},
 			"engines": {
 				"node": ">= 20"
+			}
+		},
+		"node_modules/@heroku-cli/notifications": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/@heroku-cli/notifications/-/notifications-1.2.9.tgz",
+			"integrity": "sha512-KY5+ewfbSvxoJmPLeRV2GJRcv5jcq09J5inxUUSFW4lsySj6JXN7K/ri+y7fLaW+h/Fl3xfAOLUkjCXMJ+/ptw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/@heroku-cli/schema": {
@@ -179,6 +161,34 @@
 			},
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/@heroku/socksv5": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/@heroku/socksv5/-/socksv5-0.0.9.tgz",
+			"integrity": "sha512-bV8v7R/c0gNve8i7yPmZbcCTJUqRbCnMSvcegcMaz+ly+FoZf9i4+3MTjKsX+OZn9w0w1I6VJYQBcdM+yMWPQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^5.8.8"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@heroku/socksv5/node_modules/ip-address": {
+			"version": "5.9.4",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+			"integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jsbn": "1.1.0",
+				"lodash": "^4.17.15",
+				"sprintf-js": "1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/@hono/node-server": {
@@ -888,6 +898,19 @@
 				"node": ">=8.0.0"
 			}
 		},
+		"node_modules/@opentelemetry/context-async-hooks": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+			"integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
 		"node_modules/@opentelemetry/core": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
@@ -920,6 +943,90 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-b3": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
+			"integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "1.30.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-jaeger": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
+			"integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "1.30.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
@@ -976,6 +1083,88 @@
 				"@opentelemetry/api": ">=1.3.0 <1.10.0"
 			}
 		},
+		"node_modules/@opentelemetry/sdk-trace-node": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
+			"integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/context-async-hooks": "1.30.1",
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/propagator-b3": "1.30.1",
+				"@opentelemetry/propagator-jaeger": "1.30.1",
+				"@opentelemetry/sdk-trace-base": "1.30.1",
+				"semver": "^7.5.2"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/resources": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@opentelemetry/semantic-conventions": {
 			"version": "1.43.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
@@ -985,6 +1174,72 @@
 			"engines": {
 				"node": ">=14"
 			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+			"integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@sec-ant/readable-stream": {
 			"version": "0.4.1",
@@ -1123,32 +1378,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@tokenizer/inflate": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
-			"integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.0",
-				"fflate": "^0.8.2",
-				"token-types": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
-		"node_modules/@tokenizer/token": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/debug": {
 			"version": "4.1.13",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1172,6 +1401,16 @@
 			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "26.4.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+			"integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~8.3.0"
+			}
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.15",
@@ -1198,34 +1437,14 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@xhmikosr/decompress-tar": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tar/-/decompress-tar-8.1.0.tgz",
-			"integrity": "sha512-m0q8x6lwxenh1CrsTby0Jrjq4vzW/QU1OLhTHMQLEdHpmjR1lgahGz++seZI0bXF3XcZw3U3xHfqZSz+JPP2Gg==",
+		"node_modules/@xmldom/xmldom": {
+			"version": "0.8.15",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+			"integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"file-type": "^20.5.0",
-				"is-stream": "^2.0.1",
-				"tar-stream": "^3.1.7"
-			},
 			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@xhmikosr/decompress-unzip": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@xhmikosr/decompress-unzip/-/decompress-unzip-7.1.0.tgz",
-			"integrity": "sha512-oqTYAcObqTlg8owulxFTqiaJkfv2SHsxxxz9Wg4krJAHVzGWlZsU8tAB30R6ow+aHrfv4Kub6WQ8u04NWVPUpA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"file-type": "^20.5.0",
-				"get-stream": "^6.0.1",
-				"yauzl": "^3.1.2"
-			},
-			"engines": {
-				"node": ">=18"
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/accepts": {
@@ -1243,13 +1462,13 @@
 			}
 		},
 		"node_modules/adm-zip": {
-			"version": "0.5.18",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-			"integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+			"integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12.0"
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -1370,22 +1589,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/available-typed-arrays": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"possible-typed-array-names": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/b4a": {
@@ -1529,17 +1732,6 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"node_modules/bl": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
-			}
-		},
 		"node_modules/body-parser": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
@@ -1603,14 +1795,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/boolean": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-			"integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/brace-expansion": {
 			"version": "5.0.9",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
@@ -1662,41 +1846,6 @@
 				"ieee754": "^1.1.13"
 			}
 		},
-		"node_modules/buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"node_modules/buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/buildcheck": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
@@ -1731,25 +1880,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/call-bind": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"es-define-property": "^1.0.1",
-				"get-intrinsic": "^1.3.0",
-				"set-function-length": "^1.2.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/call-bind-apply-helpers": {
@@ -2138,13 +2268,6 @@
 				"node": ">=6.6.0"
 			}
 		},
-		"node_modules/core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/cors": {
 			"version": "2.8.6",
 			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -2285,203 +2408,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/decompress": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
-			"integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"decompress-tar": "^4.0.0",
-				"decompress-tarbz2": "^4.0.0",
-				"decompress-targz": "^4.0.0",
-				"decompress-unzip": "^4.0.1",
-				"graceful-fs": "^4.1.10",
-				"make-dir": "^1.0.0",
-				"pify": "^2.3.0",
-				"strip-dirs": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/decompress-tar": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-			"integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"file-type": "^5.2.0",
-				"is-stream": "^1.1.0",
-				"tar-stream": "^1.5.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/decompress-tar/node_modules/file-type": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-			"integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/decompress-tar/node_modules/is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decompress-tar/node_modules/tar-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
-				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/decompress-tarbz2": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-			"integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"decompress-tar": "^4.1.0",
-				"file-type": "^6.1.0",
-				"is-stream": "^1.1.0",
-				"seek-bzip": "^1.0.5",
-				"unbzip2-stream": "^1.0.9"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/decompress-tarbz2/node_modules/file-type": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-			"integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/decompress-tarbz2/node_modules/is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decompress-targz": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-			"integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"decompress-tar": "^4.1.1",
-				"file-type": "^5.2.0",
-				"is-stream": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/decompress-targz/node_modules/file-type": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-			"integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/decompress-targz/node_modules/is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decompress-unzip": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
-			"integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"file-type": "^3.8.0",
-				"get-stream": "^2.2.0",
-				"pify": "^2.3.0",
-				"yauzl": "^2.4.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/decompress-unzip/node_modules/file-type": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-			"integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decompress-unzip/node_modules/get-stream": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-			"integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"object-assign": "^4.0.1",
-				"pinkie-promise": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decompress-unzip/node_modules/yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
-			}
-		},
 		"node_modules/default-browser": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
@@ -2512,24 +2438,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/define-data-property": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-define-property": "^1.0.0",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/define-lazy-prop": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -2541,24 +2449,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/define-properties": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"define-data-property": "^1.0.1",
-				"has-property-descriptors": "^1.0.0",
-				"object-keys": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/depd": {
@@ -2580,13 +2470,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/detect-node": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/devlop": {
 			"version": "1.1.0",
@@ -2750,19 +2633,6 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
-		"node_modules/envalid": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/envalid/-/envalid-8.1.0.tgz",
-			"integrity": "sha512-OT6+qVhKVyCidaGoXflb2iK1tC8pd0OV2Q+v9n33wNhUJ+lus+rJobUj4vJaQBPxPZ0vYrPGuxdrenyCAIJcow==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "2.8.1"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/environment": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -2815,13 +2685,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/es6-error": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/escape-html": {
 			"version": "1.0.3",
@@ -3065,16 +2928,6 @@
 				"reusify": "^1.0.4"
 			}
 		},
-		"node_modules/fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pend": "~1.2.0"
-			}
-		},
 		"node_modules/fetch-blob": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -3099,13 +2952,6 @@
 				"node": "^12.20 || >= 14.13"
 			}
 		},
-		"node_modules/fflate": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
-			"integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/figures": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -3120,25 +2966,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/file-type": {
-			"version": "20.5.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
-			"integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tokenizer/inflate": "^0.2.6",
-				"strtok3": "^10.2.0",
-				"token-types": "^6.0.0",
-				"uint8array-extras": "^1.4.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
 			}
 		},
 		"node_modules/fill-range": {
@@ -3184,22 +3011,6 @@
 			"license": "BSD-3-Clause",
 			"bin": {
 				"flat": "cli.js"
-			}
-		},
-		"node_modules/for-each": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-callable": "^1.2.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/formdata-polyfill": {
@@ -3357,41 +3168,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/global-agent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-			"integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"boolean": "^3.0.1",
-				"es6-error": "^4.1.1",
-				"matcher": "^3.0.0",
-				"roarr": "^2.15.3",
-				"semver": "^7.3.2",
-				"serialize-error": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=10.0"
-			}
-		},
-		"node_modules/globalthis": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"define-properties": "^1.2.1",
-				"gopd": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/globby": {
 			"version": "16.2.2",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
@@ -3443,41 +3219,12 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/has-property-descriptors": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-define-property": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/has-symbols": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-tostringtag": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-symbols": "^1.0.3"
-			},
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -3607,45 +3354,6 @@
 				"node": ">=0.1.90"
 			}
 		},
-		"node_modules/heroku/node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/heroku/node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
-		"node_modules/heroku/node_modules/@heroku-cli/notifications": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@heroku-cli/notifications/-/notifications-1.2.6.tgz",
-			"integrity": "sha512-ML4YqwR+7E2yLJhsPk/FAUksyGvmQ/D++rRhI/Ews6GTWXR67RjmmKTU5sXJLVTtQH7oV8yoDMQCIGpedk8ClQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node-notifier": "8.0.5",
-				"node-notifier": "^10.0.1",
-				"ts-node": "^10.9.2"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
 		"node_modules/heroku/node_modules/@heroku-cli/schema": {
 			"version": "1.0.25",
 			"resolved": "https://registry.npmjs.org/@heroku-cli/schema/-/schema-1.0.25.tgz",
@@ -3674,36 +3382,6 @@
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/true-myth/-/true-myth-2.2.8.tgz",
 			"integrity": "sha512-ds6rEGLDgVZZId9v+WK0kj7gc7x6LOJ8HVGGDrrWekYdJGCShGeV37z39124zgF73OtmlAqoDDZnDTmygr2D4g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/@heroku/socksv5": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/@heroku/socksv5/-/socksv5-0.0.9.tgz",
-			"integrity": "sha512-bV8v7R/c0gNve8i7yPmZbcCTJUqRbCnMSvcegcMaz+ly+FoZf9i4+3MTjKsX+OZn9w0w1I6VJYQBcdM+yMWPQQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ip-address": "^5.8.8"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@jridgewell/resolve-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4034,6 +3712,22 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/heroku/node_modules/@opentelemetry/core": {
+			"version": "1.25.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+			"integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "1.25.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
 		"node_modules/heroku/node_modules/@opentelemetry/exporter-trace-otlp-http": {
 			"version": "0.52.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.52.1.tgz",
@@ -4052,22 +3746,6 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.0.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
-			"integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.25.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/heroku/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
@@ -4103,16 +3781,6 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
-			"integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/heroku/node_modules/@opentelemetry/instrumentation": {
@@ -4153,32 +3821,6 @@
 				"@opentelemetry/api": "^1.0.0"
 			}
 		},
-		"node_modules/heroku/node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
-			"integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.25.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
-			"integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/heroku/node_modules/@opentelemetry/otlp-transformer": {
 			"version": "0.52.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.52.1.tgz",
@@ -4199,22 +3841,6 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
-			"integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.25.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/heroku/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
@@ -4250,100 +3876,6 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
-			"integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/propagator-b3": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
-			"integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "1.30.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/propagator-jaeger": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
-			"integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "1.30.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/heroku/node_modules/@opentelemetry/resources": {
@@ -4407,22 +3939,6 @@
 				"@opentelemetry/api": ">=1.4.0 <1.10.0"
 			}
 		},
-		"node_modules/heroku/node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
-			"integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.25.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
 		"node_modules/heroku/node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
 			"version": "1.25.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
@@ -4438,16 +3954,6 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
-			"integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/heroku/node_modules/@opentelemetry/sdk-metrics": {
@@ -4468,22 +3974,6 @@
 				"@opentelemetry/api": ">=1.3.0 <1.10.0"
 			}
 		},
-		"node_modules/heroku/node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
-			"integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.25.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
 		"node_modules/heroku/node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
 			"version": "1.25.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
@@ -4499,16 +3989,6 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
-			"integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/heroku/node_modules/@opentelemetry/sdk-trace-base": {
@@ -4555,60 +4035,10 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/heroku/node_modules/@opentelemetry/sdk-trace-node": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
-			"integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/context-async-hooks": "1.30.1",
-				"@opentelemetry/core": "1.30.1",
-				"@opentelemetry/propagator-b3": "1.30.1",
-				"@opentelemetry/propagator-jaeger": "1.30.1",
-				"@opentelemetry/sdk-trace-base": "1.30.1",
-				"semver": "^7.5.2"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/context-async-hooks": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
-			"integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+		"node_modules/heroku/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.25.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+			"integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -4660,80 +4090,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/heroku/node_modules/@protobufjs/aspromise": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/heroku/node_modules/@protobufjs/base64": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/heroku/node_modules/@protobufjs/codegen": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/heroku/node_modules/@protobufjs/eventemitter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/heroku/node_modules/@protobufjs/fetch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.1",
-				"@protobufjs/inquire": "^1.1.0"
-			}
-		},
-		"node_modules/heroku/node_modules/@protobufjs/float": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/heroku/node_modules/@protobufjs/inquire": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-			"integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/heroku/node_modules/@protobufjs/path": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/heroku/node_modules/@protobufjs/pool": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/heroku/node_modules/@protobufjs/utf8": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/heroku/node_modules/@sindresorhus/is": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
@@ -4764,34 +4120,6 @@
 			"version": "0.23.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
 			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/@tsconfig/node10": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-			"integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/@tsconfig/node12": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/@tsconfig/node14": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/@tsconfig/node16": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4829,16 +4157,6 @@
 				"undici-types": "~6.21.0"
 			}
 		},
-		"node_modules/heroku/node_modules/@types/node-notifier": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-8.0.5.tgz",
-			"integrity": "sha512-LX7+8MtTsv6szumAp6WOy87nqMEdGhhry/Qfprjm1Ma6REjVzeF7SCyvPtp5RaF6IkXCS9V4ra8g5fwvf2ZAYg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/heroku/node_modules/@types/shimmer": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
@@ -4852,16 +4170,6 @@
 			"integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/@xmldom/xmldom": {
-			"version": "0.8.13",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-			"integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			}
 		},
 		"node_modules/heroku/node_modules/acorn": {
 			"version": "8.15.0",
@@ -4884,19 +4192,6 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8"
-			}
-		},
-		"node_modules/heroku/node_modules/acorn-walk": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.11.0"
-			},
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/heroku/node_modules/agent-base": {
@@ -5011,13 +4306,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/heroku/node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/heroku/node_modules/ast-types": {
 			"version": "0.13.4",
@@ -5295,13 +4583,6 @@
 				"ini": "^1.3.4",
 				"proto-list": "~1.2.1"
 			}
-		},
-		"node_modules/heroku/node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/heroku/node_modules/data-uri-to-buffer": {
 			"version": "6.0.2",
@@ -5653,13 +4934,6 @@
 				"url": "https://github.com/sindresorhus/got?sponsor=1"
 			}
 		},
-		"node_modules/heroku/node_modules/growly": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-			"integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/heroku/node_modules/highlight.js": {
 			"version": "10.7.3",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -6008,21 +5282,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/heroku/node_modules/ip-address": {
-			"version": "5.9.4",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
-			"integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"jsbn": "1.1.0",
-				"lodash": "^4.17.15",
-				"sprintf-js": "1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/heroku/node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -6046,22 +5305,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/heroku/node_modules/is-docker": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"is-docker": "cli.js"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/heroku/node_modules/is-interactive": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -6083,19 +5326,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/heroku/node_modules/is-wsl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-docker": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/heroku/node_modules/isexe": {
@@ -6124,13 +5354,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/heroku/node_modules/jsbn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/heroku/node_modules/json-buffer": {
 			"version": "3.0.1",
@@ -6176,13 +5399,6 @@
 				"json-buffer": "3.0.1"
 			}
 		},
-		"node_modules/heroku/node_modules/lodash.merge": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/heroku/node_modules/log-symbols": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -6200,13 +5416,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/heroku/node_modules/long": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
 		"node_modules/heroku/node_modules/lowercase-keys": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
@@ -6219,13 +5428,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/heroku/node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/heroku/node_modules/marked": {
 			"version": "15.0.12",
@@ -6587,55 +5789,6 @@
 				"node": ">= 6.13.0"
 			}
 		},
-		"node_modules/heroku/node_modules/node-notifier": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
-			"integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"growly": "^1.3.0",
-				"is-wsl": "^2.2.0",
-				"semver": "^7.3.5",
-				"shellwords": "^0.1.1",
-				"uuid": "^8.3.2",
-				"which": "^2.0.2"
-			}
-		},
-		"node_modules/heroku/node_modules/node-notifier/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/heroku/node_modules/node-notifier/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
-		"node_modules/heroku/node_modules/node-notifier/node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/heroku/node_modules/normalize-url": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
@@ -6647,161 +5800,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/heroku/node_modules/npm": {
-			"version": "11.16.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-11.16.0.tgz",
-			"integrity": "sha512-A74XL8OxmcegZDMWPkWb5bEQppg8HdYwW3rBD2sPoS4UQHVajfaxBkqyzLeJ3wR0kZ+5xoTjItxXaF7eIXUsyw==",
-			"bundleDependencies": [
-				"@isaacs/string-locale-compare",
-				"@npmcli/arborist",
-				"@npmcli/config",
-				"@npmcli/fs",
-				"@npmcli/map-workspaces",
-				"@npmcli/metavuln-calculator",
-				"@npmcli/package-json",
-				"@npmcli/promise-spawn",
-				"@npmcli/redact",
-				"@npmcli/run-script",
-				"@sigstore/tuf",
-				"abbrev",
-				"archy",
-				"cacache",
-				"chalk",
-				"ci-info",
-				"fastest-levenshtein",
-				"fs-minipass",
-				"glob",
-				"graceful-fs",
-				"hosted-git-info",
-				"ini",
-				"init-package-json",
-				"is-cidr",
-				"json-parse-even-better-errors",
-				"libnpmaccess",
-				"libnpmdiff",
-				"libnpmexec",
-				"libnpmfund",
-				"libnpmorg",
-				"libnpmpack",
-				"libnpmpublish",
-				"libnpmsearch",
-				"libnpmteam",
-				"libnpmversion",
-				"make-fetch-happen",
-				"minimatch",
-				"minipass",
-				"minipass-pipeline",
-				"ms",
-				"node-gyp",
-				"nopt",
-				"npm-audit-report",
-				"npm-install-checks",
-				"npm-package-arg",
-				"npm-pick-manifest",
-				"npm-profile",
-				"npm-registry-fetch",
-				"npm-user-validate",
-				"p-map",
-				"pacote",
-				"parse-conflict-json",
-				"proc-log",
-				"qrcode-terminal",
-				"read",
-				"semver",
-				"spdx-expression-parse",
-				"ssri",
-				"supports-color",
-				"tar",
-				"text-table",
-				"tiny-relative-date",
-				"treeverse",
-				"validate-npm-package-name",
-				"which"
-			],
-			"dev": true,
-			"license": "Artistic-2.0",
-			"workspaces": [
-				"docs",
-				"smoke-tests",
-				"mock-globals",
-				"mock-registry",
-				"workspaces/*"
-			],
-			"dependencies": {
-				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^9.7.0",
-				"@npmcli/config": "^10.10.0",
-				"@npmcli/fs": "^5.0.0",
-				"@npmcli/map-workspaces": "^5.0.3",
-				"@npmcli/metavuln-calculator": "^9.0.3",
-				"@npmcli/package-json": "^7.0.5",
-				"@npmcli/promise-spawn": "^9.0.1",
-				"@npmcli/redact": "^4.0.0",
-				"@npmcli/run-script": "^10.0.4",
-				"@sigstore/tuf": "^4.0.2",
-				"abbrev": "^4.0.0",
-				"archy": "~1.0.0",
-				"cacache": "^20.0.4",
-				"chalk": "^5.6.2",
-				"ci-info": "^4.4.0",
-				"fastest-levenshtein": "^1.0.16",
-				"fs-minipass": "^3.0.3",
-				"glob": "^13.0.6",
-				"graceful-fs": "^4.2.11",
-				"hosted-git-info": "^9.0.3",
-				"ini": "^6.0.0",
-				"init-package-json": "^8.2.5",
-				"is-cidr": "^6.0.4",
-				"json-parse-even-better-errors": "^5.0.0",
-				"libnpmaccess": "^10.0.3",
-				"libnpmdiff": "^8.1.9",
-				"libnpmexec": "^10.2.9",
-				"libnpmfund": "^7.0.23",
-				"libnpmorg": "^8.0.1",
-				"libnpmpack": "^9.1.9",
-				"libnpmpublish": "^11.2.0",
-				"libnpmsearch": "^9.0.1",
-				"libnpmteam": "^8.0.2",
-				"libnpmversion": "^8.0.4",
-				"make-fetch-happen": "^15.0.6",
-				"minimatch": "^10.2.5",
-				"minipass": "^7.1.3",
-				"minipass-pipeline": "^1.2.4",
-				"ms": "^2.1.2",
-				"node-gyp": "^12.3.0",
-				"nopt": "^9.0.0",
-				"npm-audit-report": "^7.0.0",
-				"npm-install-checks": "^8.0.0",
-				"npm-package-arg": "^13.0.2",
-				"npm-pick-manifest": "^11.0.3",
-				"npm-profile": "^12.0.1",
-				"npm-registry-fetch": "^19.1.1",
-				"npm-user-validate": "^4.0.0",
-				"p-map": "^7.0.4",
-				"pacote": "^21.5.0",
-				"parse-conflict-json": "^5.0.1",
-				"proc-log": "^6.1.0",
-				"qrcode-terminal": "^0.12.0",
-				"read": "^5.0.1",
-				"semver": "^7.8.1",
-				"spdx-expression-parse": "^4.0.0",
-				"ssri": "^13.0.1",
-				"supports-color": "^10.2.2",
-				"tar": "^7.5.15",
-				"text-table": "~0.2.0",
-				"tiny-relative-date": "^2.0.2",
-				"treeverse": "^3.0.0",
-				"validate-npm-package-name": "^7.0.2",
-				"which": "^6.0.1"
-			},
-			"bin": {
-				"npm": "bin/npm-cli.js",
-				"npx": "bin/npx-cli.js"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/heroku/node_modules/npm-package-arg": {
@@ -6867,1758 +5865,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@gar/promise-retry": {
-			"version": "1.0.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@isaacs/fs-minipass": {
-			"version": "4.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.4"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@isaacs/string-locale-compare": {
-			"version": "1.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/agent": {
-			"version": "4.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^11.2.1",
-				"socks-proxy-agent": "^8.0.3"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "9.7.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@gar/promise-retry": "^1.0.0",
-				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/fs": "^5.0.0",
-				"@npmcli/installed-package-contents": "^4.0.0",
-				"@npmcli/map-workspaces": "^5.0.0",
-				"@npmcli/metavuln-calculator": "^9.0.2",
-				"@npmcli/name-from-folder": "^4.0.0",
-				"@npmcli/node-gyp": "^5.0.0",
-				"@npmcli/package-json": "^7.0.0",
-				"@npmcli/query": "^5.0.0",
-				"@npmcli/redact": "^4.0.0",
-				"@npmcli/run-script": "^10.0.0",
-				"bin-links": "^6.0.0",
-				"cacache": "^20.0.1",
-				"common-ancestor-path": "^2.0.0",
-				"hosted-git-info": "^9.0.0",
-				"json-stringify-nice": "^1.1.4",
-				"lru-cache": "^11.2.1",
-				"minimatch": "^10.0.3",
-				"nopt": "^9.0.0",
-				"npm-install-checks": "^8.0.0",
-				"npm-package-arg": "^13.0.0",
-				"npm-pick-manifest": "^11.0.1",
-				"npm-registry-fetch": "^19.0.0",
-				"pacote": "^21.0.2",
-				"parse-conflict-json": "^5.0.1",
-				"proc-log": "^6.0.0",
-				"proggy": "^4.0.0",
-				"promise-all-reject-late": "^1.0.0",
-				"promise-call-limit": "^3.0.1",
-				"semver": "^7.3.7",
-				"ssri": "^13.0.0",
-				"treeverse": "^3.0.0",
-				"walk-up-path": "^4.0.0"
-			},
-			"bin": {
-				"arborist": "bin/index.js"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/config": {
-			"version": "10.10.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/map-workspaces": "^5.0.0",
-				"@npmcli/package-json": "^7.0.0",
-				"ci-info": "^4.0.0",
-				"ini": "^6.0.0",
-				"nopt": "^9.0.0",
-				"proc-log": "^6.0.0",
-				"semver": "^7.3.5",
-				"walk-up-path": "^4.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/fs": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/git": {
-			"version": "7.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@gar/promise-retry": "^1.0.0",
-				"@npmcli/promise-spawn": "^9.0.0",
-				"ini": "^6.0.0",
-				"lru-cache": "^11.2.1",
-				"npm-pick-manifest": "^11.0.1",
-				"proc-log": "^6.0.0",
-				"semver": "^7.3.5",
-				"which": "^6.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-bundled": "^5.0.0",
-				"npm-normalize-package-bin": "^5.0.0"
-			},
-			"bin": {
-				"installed-package-contents": "bin/index.js"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/map-workspaces": {
-			"version": "5.0.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/name-from-folder": "^4.0.0",
-				"@npmcli/package-json": "^7.0.0",
-				"glob": "^13.0.0",
-				"minimatch": "^10.0.3"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-			"version": "9.0.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"cacache": "^20.0.0",
-				"json-parse-even-better-errors": "^5.0.0",
-				"pacote": "^21.0.0",
-				"proc-log": "^6.0.0",
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/name-from-folder": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/node-gyp": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/package-json": {
-			"version": "7.0.5",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/git": "^7.0.0",
-				"glob": "^13.0.0",
-				"hosted-git-info": "^9.0.0",
-				"json-parse-even-better-errors": "^5.0.0",
-				"proc-log": "^6.0.0",
-				"semver": "^7.5.3",
-				"spdx-expression-parse": "^4.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/promise-spawn": {
-			"version": "9.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"which": "^6.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/query": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"postcss-selector-parser": "^7.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/redact": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@npmcli/run-script": {
-			"version": "10.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/node-gyp": "^5.0.0",
-				"@npmcli/package-json": "^7.0.0",
-				"@npmcli/promise-spawn": "^9.0.0",
-				"node-gyp": "^12.1.0",
-				"proc-log": "^6.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@sigstore/bundle": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.5.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@sigstore/core": {
-			"version": "3.2.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-			"version": "0.5.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@sigstore/sign": {
-			"version": "4.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@gar/promise-retry": "^1.0.2",
-				"@sigstore/bundle": "^4.0.0",
-				"@sigstore/core": "^3.2.0",
-				"@sigstore/protobuf-specs": "^0.5.0",
-				"make-fetch-happen": "^15.0.4",
-				"proc-log": "^6.1.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@sigstore/tuf": {
-			"version": "4.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.5.0",
-				"tuf-js": "^4.1.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@sigstore/verify": {
-			"version": "3.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^4.0.0",
-				"@sigstore/core": "^3.2.1",
-				"@sigstore/protobuf-specs": "^0.5.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@tufjs/canonical-json": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/@tufjs/models": {
-			"version": "4.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tufjs/canonical-json": "2.0.0",
-				"minimatch": "^10.1.1"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/abbrev": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/agent-base": {
-			"version": "7.1.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/aproba": {
-			"version": "2.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/archy": {
-			"version": "1.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/bin-links": {
-			"version": "6.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"cmd-shim": "^8.0.0",
-				"npm-normalize-package-bin": "^5.0.0",
-				"proc-log": "^6.0.0",
-				"read-cmd-shim": "^6.0.0",
-				"write-file-atomic": "^7.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/binary-extensions": {
-			"version": "3.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/cacache": {
-			"version": "20.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/fs": "^5.0.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^13.0.0",
-				"lru-cache": "^11.1.0",
-				"minipass": "^7.0.3",
-				"minipass-collect": "^2.0.1",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"p-map": "^7.0.2",
-				"ssri": "^13.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/chalk": {
-			"version": "5.6.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/chownr": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/ci-info": {
-			"version": "4.4.0",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/cidr-regex": {
-			"version": "5.0.5",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/cmd-shim": {
-			"version": "8.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/common-ancestor-path": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/cssesc": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"bin": {
-				"cssesc": "bin/cssesc"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/debug": {
-			"version": "4.4.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/diff": {
-			"version": "8.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.3.1"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/env-paths": {
-			"version": "2.2.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/exponential-backoff": {
-			"version": "3.1.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/fastest-levenshtein": {
-			"version": "1.0.16",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.9.1"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/fs-minipass": {
-			"version": "3.0.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/glob": {
-			"version": "13.0.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"minimatch": "^10.2.2",
-				"minipass": "^7.1.3",
-				"path-scurry": "^2.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/graceful-fs": {
-			"version": "4.2.11",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/hosted-git-info": {
-			"version": "9.0.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^11.1.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/http-cache-semantics": {
-			"version": "4.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/iconv-lite": {
-			"version": "0.7.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/ignore-walk": {
-			"version": "8.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minimatch": "^10.0.3"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/ini": {
-			"version": "6.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/init-package-json": {
-			"version": "8.2.5",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/package-json": "^7.0.0",
-				"npm-package-arg": "^13.0.0",
-				"promzard": "^3.0.1",
-				"read": "^5.0.1",
-				"semver": "^7.7.2",
-				"validate-npm-package-name": "^7.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/ip-address": {
-			"version": "10.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/is-cidr": {
-			"version": "6.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"cidr-regex": "^5.0.4"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/isexe": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/json-parse-even-better-errors": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/json-stringify-nice": {
-			"version": "1.1.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/jsonparse": {
-			"version": "1.3.1",
-			"dev": true,
-			"engines": [
-				"node >= 0.2.0"
-			],
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/just-diff": {
-			"version": "6.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/just-diff-apply": {
-			"version": "5.5.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/libnpmaccess": {
-			"version": "10.0.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-package-arg": "^13.0.0",
-				"npm-registry-fetch": "^19.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/libnpmdiff": {
-			"version": "8.1.9",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/arborist": "^9.7.0",
-				"@npmcli/installed-package-contents": "^4.0.0",
-				"binary-extensions": "^3.0.0",
-				"diff": "^8.0.2",
-				"minimatch": "^10.0.3",
-				"npm-package-arg": "^13.0.0",
-				"pacote": "^21.0.2",
-				"tar": "^7.5.1"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/libnpmexec": {
-			"version": "10.2.9",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@gar/promise-retry": "^1.0.0",
-				"@npmcli/arborist": "^9.7.0",
-				"@npmcli/package-json": "^7.0.0",
-				"@npmcli/run-script": "^10.0.0",
-				"ci-info": "^4.0.0",
-				"npm-package-arg": "^13.0.0",
-				"pacote": "^21.0.2",
-				"proc-log": "^6.0.0",
-				"read": "^5.0.1",
-				"semver": "^7.3.7",
-				"signal-exit": "^4.1.0",
-				"walk-up-path": "^4.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/libnpmfund": {
-			"version": "7.0.23",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/arborist": "^9.7.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/libnpmorg": {
-			"version": "8.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^19.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/libnpmpack": {
-			"version": "9.1.9",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/arborist": "^9.7.0",
-				"@npmcli/run-script": "^10.0.0",
-				"npm-package-arg": "^13.0.0",
-				"pacote": "^21.0.2"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/libnpmpublish": {
-			"version": "11.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/package-json": "^7.0.0",
-				"ci-info": "^4.0.0",
-				"npm-package-arg": "^13.0.0",
-				"npm-registry-fetch": "^19.0.0",
-				"proc-log": "^6.0.0",
-				"semver": "^7.3.7",
-				"sigstore": "^4.0.0",
-				"ssri": "^13.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/libnpmsearch": {
-			"version": "9.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-registry-fetch": "^19.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/libnpmteam": {
-			"version": "8.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^19.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/libnpmversion": {
-			"version": "8.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/git": "^7.0.0",
-				"@npmcli/run-script": "^10.0.0",
-				"json-parse-even-better-errors": "^5.0.0",
-				"proc-log": "^6.0.0",
-				"semver": "^7.3.7"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/lru-cache": {
-			"version": "11.5.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "15.0.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@gar/promise-retry": "^1.0.0",
-				"@npmcli/agent": "^4.0.0",
-				"@npmcli/redact": "^4.0.0",
-				"cacache": "^20.0.1",
-				"http-cache-semantics": "^4.1.1",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^5.0.0",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^1.0.0",
-				"proc-log": "^6.0.0",
-				"ssri": "^13.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/minimatch": {
-			"version": "10.2.5",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"brace-expansion": "^5.0.5"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/minipass": {
-			"version": "7.1.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/minipass-collect": {
-			"version": "2.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/minipass-fetch": {
-			"version": "5.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.0.3",
-				"minipass-sized": "^2.0.0",
-				"minizlib": "^3.0.1"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			},
-			"optionalDependencies": {
-				"iconv-lite": "^0.7.2"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/minipass-flush": {
-			"version": "1.0.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"minipass": "^7.1.3"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/minipass-pipeline": {
-			"version": "1.2.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/minipass-sized": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/minizlib": {
-			"version": "3.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/ms": {
-			"version": "2.1.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/mute-stream": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/negotiator": {
-			"version": "1.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/node-gyp": {
-			"version": "12.3.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"env-paths": "^2.2.0",
-				"exponential-backoff": "^3.1.1",
-				"graceful-fs": "^4.2.6",
-				"nopt": "^9.0.0",
-				"proc-log": "^6.0.0",
-				"semver": "^7.3.5",
-				"tar": "^7.5.4",
-				"tinyglobby": "^0.2.12",
-				"undici": "^6.25.0",
-				"which": "^6.0.0"
-			},
-			"bin": {
-				"node-gyp": "bin/node-gyp.js"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/nopt": {
-			"version": "9.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"abbrev": "^4.0.0"
-			},
-			"bin": {
-				"nopt": "bin/nopt.js"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/npm-audit-report": {
-			"version": "7.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/npm-bundled": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-normalize-package-bin": "^5.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/npm-install-checks": {
-			"version": "8.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"semver": "^7.1.1"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/npm-normalize-package-bin": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/npm-package-arg": {
-			"version": "13.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"hosted-git-info": "^9.0.0",
-				"proc-log": "^6.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-name": "^7.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/npm-packlist": {
-			"version": "10.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"ignore-walk": "^8.0.0",
-				"proc-log": "^6.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/npm-pick-manifest": {
-			"version": "11.0.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-install-checks": "^8.0.0",
-				"npm-normalize-package-bin": "^5.0.0",
-				"npm-package-arg": "^13.0.0",
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/npm-profile": {
-			"version": "12.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-registry-fetch": "^19.0.0",
-				"proc-log": "^6.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/npm-registry-fetch": {
-			"version": "19.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/redact": "^4.0.0",
-				"jsonparse": "^1.3.1",
-				"make-fetch-happen": "^15.0.0",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^5.0.0",
-				"minizlib": "^3.0.1",
-				"npm-package-arg": "^13.0.0",
-				"proc-log": "^6.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/npm-user-validate": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/p-map": {
-			"version": "7.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/pacote": {
-			"version": "21.5.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@gar/promise-retry": "^1.0.0",
-				"@npmcli/git": "^7.0.0",
-				"@npmcli/installed-package-contents": "^4.0.0",
-				"@npmcli/package-json": "^7.0.0",
-				"@npmcli/promise-spawn": "^9.0.0",
-				"@npmcli/run-script": "^10.0.0",
-				"cacache": "^20.0.0",
-				"fs-minipass": "^3.0.0",
-				"minipass": "^7.0.2",
-				"npm-package-arg": "^13.0.0",
-				"npm-packlist": "^10.0.1",
-				"npm-pick-manifest": "^11.0.1",
-				"npm-registry-fetch": "^19.0.0",
-				"proc-log": "^6.0.0",
-				"sigstore": "^4.0.0",
-				"ssri": "^13.0.0",
-				"tar": "^7.4.3"
-			},
-			"bin": {
-				"pacote": "bin/index.js"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/parse-conflict-json": {
-			"version": "5.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"json-parse-even-better-errors": "^5.0.0",
-				"just-diff": "^6.0.0",
-				"just-diff-apply": "^5.2.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/path-scurry": {
-			"version": "2.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"lru-cache": "^11.0.0",
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/postcss-selector-parser": {
-			"version": "7.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/proc-log": {
-			"version": "6.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/proggy": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/promise-all-reject-late": {
-			"version": "1.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/promise-call-limit": {
-			"version": "3.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/promzard": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"read": "^5.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/qrcode-terminal": {
-			"version": "0.12.0",
-			"dev": true,
-			"inBundle": true,
-			"bin": {
-				"qrcode-terminal": "bin/qrcode-terminal.js"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/read": {
-			"version": "5.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"mute-stream": "^3.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/read-cmd-shim": {
-			"version": "6.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/safer-buffer": {
-			"version": "2.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/semver": {
-			"version": "7.8.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/sigstore": {
-			"version": "4.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^4.0.0",
-				"@sigstore/core": "^3.2.1",
-				"@sigstore/protobuf-specs": "^0.5.0",
-				"@sigstore/sign": "^4.1.1",
-				"@sigstore/tuf": "^4.0.2",
-				"@sigstore/verify": "^3.1.1"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/smart-buffer": {
-			"version": "4.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 6.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/socks": {
-			"version": "2.8.9",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ip-address": "^10.1.1",
-				"smart-buffer": "^4.2.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/socks-proxy-agent": {
-			"version": "8.0.5",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"socks": "^2.8.3"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/spdx-exceptions": {
-			"version": "2.5.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "CC-BY-3.0"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/spdx-expression-parse": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/spdx-license-ids": {
-			"version": "3.0.23",
-			"dev": true,
-			"inBundle": true,
-			"license": "CC0-1.0"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/ssri": {
-			"version": "13.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/supports-color": {
-			"version": "10.2.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/tar": {
-			"version": "7.5.15",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/text-table": {
-			"version": "0.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/tiny-relative-date": {
-			"version": "2.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/tinyglobby": {
-			"version": "0.2.16",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"fdir": "^6.5.0",
-				"picomatch": "^4.0.4"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/SuperchupuDev"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.5.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/treeverse": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/tuf-js": {
-			"version": "4.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tufjs/models": "4.1.0",
-				"debug": "^4.4.3",
-				"make-fetch-happen": "^15.0.1"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/undici": {
-			"version": "6.26.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.17"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/validate-npm-package-name": {
-			"version": "7.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/walk-up-path": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/which": {
-			"version": "6.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^4.0.0"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/write-file-atomic": {
-			"version": "7.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/heroku/node_modules/npm/node_modules/yallist": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/heroku/node_modules/object-treeify": {
@@ -8810,13 +6056,6 @@
 				"node": "20 || >=22"
 			}
 		},
-		"node_modules/heroku/node_modules/phoenix": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.8.3.tgz",
-			"integrity": "sha512-5bMYQI30wl3erxbHnXMdt1xuQeRTeEOpQrakf3yqj/1HRHl7Gj4Cdk2NKXkUcCD5WpbxrilvZEMexM1VhWbnDg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/heroku/node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8869,31 +6108,6 @@
 			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/heroku/node_modules/protobufjs": {
-			"version": "7.5.8",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-			"integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.5",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.1",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.1",
-				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
 		},
 		"node_modules/heroku/node_modules/proxy-agent": {
 			"version": "6.5.0",
@@ -9086,13 +6300,6 @@
 				"node": ">=0.12.0"
 			}
 		},
-		"node_modules/heroku/node_modules/shellwords": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/heroku/node_modules/shimmer": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
@@ -9154,16 +6361,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/heroku/node_modules/socks/node_modules/ip-address": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
 		"node_modules/heroku/node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9174,13 +6371,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/heroku/node_modules/sprintf-js": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-			"dev": true,
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/heroku/node_modules/strftime": {
 			"version": "0.10.3",
@@ -9367,16 +6557,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/heroku/node_modules/tmp": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-			"integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
 		"node_modules/heroku/node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -9394,60 +6574,6 @@
 				"node": "10.* || >= 12.*"
 			}
 		},
-		"node_modules/heroku/node_modules/ts-node": {
-			"version": "10.9.2",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/heroku/node_modules/ts-node/node_modules/diff": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.3.1"
-			}
-		},
 		"node_modules/heroku/node_modules/type-fest": {
 			"version": "0.21.3",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
@@ -9459,21 +6585,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/heroku/node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=14.17"
 			}
 		},
 		"node_modules/heroku/node_modules/undici-types": {
@@ -9507,13 +6618,6 @@
 			"version": "1.19.11",
 			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
 			"integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/heroku/node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -9597,9 +6701,9 @@
 			}
 		},
 		"node_modules/heroku/node_modules/ws": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-			"integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+			"version": "6.2.6",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.6.tgz",
+			"integrity": "sha512-XTrf1gv7kXoVf1hbC3PAyAiPgR8Wz1blcrYIjEsUmr08BLksT41R8KbjmS9408C2ERx7v1JDLD/BkpLEttjfKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9617,22 +6721,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/heroku/node_modules/wsl-utils/node_modules/is-wsl": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-inside-container": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -9701,16 +6789,6 @@
 			},
 			"engines": {
 				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/heroku/node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/hono": {
@@ -10136,19 +7214,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/is-callable": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-decimal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
@@ -10271,13 +7336,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-natural-number": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-			"integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -10347,22 +7405,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-typed-array": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"which-typed-array": "^1.1.16"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-unicode-supported": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -10391,13 +7433,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -10446,6 +7481,13 @@
 				"js-yaml": "bin/js-yaml.mjs"
 			}
 		},
+		"node_modules/jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -10459,13 +7501,6 @@
 			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
 			"dev": true,
 			"license": "BSD-2-Clause"
-		},
-		"node_modules/json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/jsonc-parser": {
 			"version": "3.3.1",
@@ -10561,6 +7596,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -10572,29 +7621,6 @@
 			},
 			"bin": {
 				"loose-envify": "cli.js"
-			}
-		},
-		"node_modules/make-dir": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pify": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/make-dir/node_modules/pify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/markdown-it": {
@@ -10704,19 +7730,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/matcher": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-			"integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -11512,6 +8525,161 @@
 				"url": "https://opencollective.com/node-fetch"
 			}
 		},
+		"node_modules/npm": {
+			"version": "11.19.1",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-11.19.1.tgz",
+			"integrity": "sha512-ztsxKxt/kkIaAs+2i0GU6I+DRmUdrNasxTZKJe9TCdSjKxlhah/4r/hl5ygMD6XAg1qZ9c2TNomR4qgOydp10g==",
+			"bundleDependencies": [
+				"@isaacs/string-locale-compare",
+				"@npmcli/arborist",
+				"@npmcli/config",
+				"@npmcli/fs",
+				"@npmcli/map-workspaces",
+				"@npmcli/metavuln-calculator",
+				"@npmcli/package-json",
+				"@npmcli/promise-spawn",
+				"@npmcli/redact",
+				"@npmcli/run-script",
+				"@sigstore/tuf",
+				"abbrev",
+				"archy",
+				"cacache",
+				"chalk",
+				"ci-info",
+				"fastest-levenshtein",
+				"fs-minipass",
+				"glob",
+				"graceful-fs",
+				"hosted-git-info",
+				"ini",
+				"init-package-json",
+				"is-cidr",
+				"json-parse-even-better-errors",
+				"libnpmaccess",
+				"libnpmdiff",
+				"libnpmexec",
+				"libnpmfund",
+				"libnpmorg",
+				"libnpmpack",
+				"libnpmpublish",
+				"libnpmsearch",
+				"libnpmteam",
+				"libnpmversion",
+				"make-fetch-happen",
+				"minimatch",
+				"minipass",
+				"minipass-pipeline",
+				"ms",
+				"node-gyp",
+				"nopt",
+				"npm-audit-report",
+				"npm-install-checks",
+				"npm-package-arg",
+				"npm-pick-manifest",
+				"npm-profile",
+				"npm-registry-fetch",
+				"npm-user-validate",
+				"p-map",
+				"pacote",
+				"parse-conflict-json",
+				"proc-log",
+				"qrcode-terminal",
+				"read",
+				"semver",
+				"spdx-expression-parse",
+				"ssri",
+				"supports-color",
+				"tar",
+				"text-table",
+				"tiny-relative-date",
+				"treeverse",
+				"validate-npm-package-name",
+				"which"
+			],
+			"dev": true,
+			"license": "Artistic-2.0",
+			"workspaces": [
+				"docs",
+				"smoke-tests",
+				"mock-globals",
+				"mock-registry",
+				"workspaces/*"
+			],
+			"dependencies": {
+				"@isaacs/string-locale-compare": "^1.1.0",
+				"@npmcli/arborist": "^9.9.1",
+				"@npmcli/config": "^10.12.0",
+				"@npmcli/fs": "^5.0.0",
+				"@npmcli/map-workspaces": "^5.0.3",
+				"@npmcli/metavuln-calculator": "^9.0.3",
+				"@npmcli/package-json": "^7.0.5",
+				"@npmcli/promise-spawn": "^9.0.1",
+				"@npmcli/redact": "^4.0.0",
+				"@npmcli/run-script": "^10.0.4",
+				"@sigstore/tuf": "^4.0.2",
+				"abbrev": "^4.0.0",
+				"archy": "~1.0.0",
+				"cacache": "^20.0.4",
+				"chalk": "^5.6.2",
+				"ci-info": "^4.4.0",
+				"fastest-levenshtein": "^1.0.16",
+				"fs-minipass": "^3.0.3",
+				"glob": "^13.0.6",
+				"graceful-fs": "^4.2.11",
+				"hosted-git-info": "^9.0.3",
+				"ini": "^6.0.0",
+				"init-package-json": "^8.2.5",
+				"is-cidr": "^6.0.4",
+				"json-parse-even-better-errors": "^5.0.0",
+				"libnpmaccess": "^10.0.3",
+				"libnpmdiff": "^8.1.12",
+				"libnpmexec": "^10.3.2",
+				"libnpmfund": "^7.0.26",
+				"libnpmorg": "^8.0.1",
+				"libnpmpack": "^9.1.13",
+				"libnpmpublish": "^11.2.0",
+				"libnpmsearch": "^9.0.1",
+				"libnpmteam": "^8.0.2",
+				"libnpmversion": "^8.0.4",
+				"make-fetch-happen": "^15.0.6",
+				"minimatch": "^10.2.5",
+				"minipass": "^7.1.3",
+				"minipass-pipeline": "^1.2.4",
+				"ms": "^2.1.2",
+				"node-gyp": "^12.4.0",
+				"nopt": "^9.0.0",
+				"npm-audit-report": "^7.0.0",
+				"npm-install-checks": "^8.0.0",
+				"npm-package-arg": "^13.0.2",
+				"npm-pick-manifest": "^11.0.3",
+				"npm-profile": "^12.0.2",
+				"npm-registry-fetch": "^19.1.1",
+				"npm-user-validate": "^4.0.0",
+				"p-map": "^7.0.4",
+				"pacote": "^21.5.1",
+				"parse-conflict-json": "^5.0.1",
+				"proc-log": "^6.1.0",
+				"qrcode-terminal": "^0.12.0",
+				"read": "^5.0.1",
+				"semver": "^7.8.5",
+				"spdx-expression-parse": "^4.0.0",
+				"ssri": "^13.0.1",
+				"supports-color": "^10.2.2",
+				"tar": "^7.5.22",
+				"text-table": "~0.2.0",
+				"tiny-relative-date": "^2.0.2",
+				"treeverse": "^3.0.0",
+				"validate-npm-package-name": "^7.0.2",
+				"which": "^6.0.1"
+			},
+			"bin": {
+				"npm": "bin/npm-cli.js",
+				"npx": "bin/npx-cli.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/npm-run-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -11553,6 +8721,1758 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/@gar/promise-retry": {
+			"version": "1.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/fs-minipass": {
+			"version": "4.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.4"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+			"version": "1.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/@npmcli/agent": {
+			"version": "4.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.1",
+				"lru-cache": "^11.2.1",
+				"socks-proxy-agent": "^8.0.3"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/arborist": {
+			"version": "9.9.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@gar/promise-retry": "^1.0.0",
+				"@isaacs/string-locale-compare": "^1.1.0",
+				"@npmcli/fs": "^5.0.0",
+				"@npmcli/installed-package-contents": "^4.0.0",
+				"@npmcli/map-workspaces": "^5.0.0",
+				"@npmcli/metavuln-calculator": "^9.0.2",
+				"@npmcli/name-from-folder": "^4.0.0",
+				"@npmcli/node-gyp": "^5.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/query": "^5.0.0",
+				"@npmcli/redact": "^4.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"bin-links": "^6.0.0",
+				"cacache": "^20.0.1",
+				"common-ancestor-path": "^2.0.0",
+				"hosted-git-info": "^9.0.0",
+				"json-stringify-nice": "^1.1.4",
+				"lru-cache": "^11.2.1",
+				"minimatch": "^10.0.3",
+				"nopt": "^9.0.0",
+				"npm-install-checks": "^8.0.0",
+				"npm-package-arg": "^13.0.0",
+				"npm-pick-manifest": "^11.0.1",
+				"npm-registry-fetch": "^19.0.0",
+				"pacote": "^21.0.2",
+				"parse-conflict-json": "^5.0.1",
+				"proc-log": "^6.0.0",
+				"proggy": "^4.0.0",
+				"promise-all-reject-late": "^1.0.0",
+				"promise-call-limit": "^3.0.1",
+				"semver": "^7.3.7",
+				"ssri": "^13.0.0",
+				"treeverse": "^3.0.0",
+				"walk-up-path": "^4.0.0"
+			},
+			"bin": {
+				"arborist": "bin/index.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/config": {
+			"version": "10.12.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/map-workspaces": "^5.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"ci-info": "^4.0.0",
+				"ini": "^6.0.0",
+				"nopt": "^9.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.5",
+				"walk-up-path": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/fs": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/git": {
+			"version": "7.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"ini": "^6.0.0",
+				"lru-cache": "^11.2.1",
+				"npm-pick-manifest": "^11.0.1",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.5",
+				"which": "^6.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-bundled": "^5.0.0",
+				"npm-normalize-package-bin": "^5.0.0"
+			},
+			"bin": {
+				"installed-package-contents": "bin/index.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
+			"version": "5.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/name-from-folder": "^4.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"glob": "^13.0.0",
+				"minimatch": "^10.0.3"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+			"version": "9.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"cacache": "^20.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
+				"pacote": "^21.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/name-from-folder": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/node-gyp": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/package-json": {
+			"version": "7.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^7.0.0",
+				"glob": "^13.0.0",
+				"hosted-git-info": "^9.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.5.3",
+				"spdx-expression-parse": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/promise-spawn": {
+			"version": "9.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"which": "^6.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/query": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"postcss-selector-parser": "^7.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/redact": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/run-script": {
+			"version": "10.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/node-gyp": "^5.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"node-gyp": "^12.1.0",
+				"proc-log": "^6.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/bundle": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/protobuf-specs": "^0.5.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/core": {
+			"version": "3.2.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+			"version": "0.5.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign": {
+			"version": "4.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@gar/promise-retry": "^1.0.2",
+				"@sigstore/bundle": "^4.0.0",
+				"@sigstore/core": "^3.2.0",
+				"@sigstore/protobuf-specs": "^0.5.0",
+				"make-fetch-happen": "^15.0.4",
+				"proc-log": "^6.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/tuf": {
+			"version": "4.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/protobuf-specs": "^0.5.0",
+				"tuf-js": "^4.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/verify": {
+			"version": "3.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^4.0.0",
+				"@sigstore/core": "^3.2.1",
+				"@sigstore/protobuf-specs": "^0.5.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@tufjs/canonical-json": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@tufjs/models": {
+			"version": "4.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tufjs/canonical-json": "2.0.0",
+				"minimatch": "^10.1.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/abbrev": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/agent-base": {
+			"version": "7.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/aproba": {
+			"version": "2.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/archy": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/npm/node_modules/bin-links": {
+			"version": "6.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"cmd-shim": "^8.0.0",
+				"npm-normalize-package-bin": "^5.0.0",
+				"proc-log": "^6.0.0",
+				"read-cmd-shim": "^6.0.0",
+				"write-file-atomic": "^7.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/binary-extensions": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/brace-expansion": {
+			"version": "5.0.9",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/npm/node_modules/cacache": {
+			"version": "20.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/fs": "^5.0.0",
+				"fs-minipass": "^3.0.0",
+				"glob": "^13.0.0",
+				"lru-cache": "^11.1.0",
+				"minipass": "^7.0.3",
+				"minipass-collect": "^2.0.1",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"p-map": "^7.0.2",
+				"ssri": "^13.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/chalk": {
+			"version": "5.6.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/chownr": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/npm/node_modules/ci-info": {
+			"version": "4.4.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/cidr-regex": {
+			"version": "5.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/npm/node_modules/cmd-shim": {
+			"version": "8.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/common-ancestor-path": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/npm/node_modules/cssesc": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"cssesc": "bin/cssesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npm/node_modules/debug": {
+			"version": "4.4.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/npm/node_modules/diff": {
+			"version": "8.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/npm/node_modules/env-paths": {
+			"version": "2.2.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npm/node_modules/exponential-backoff": {
+			"version": "3.1.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/npm/node_modules/fastest-levenshtein": {
+			"version": "1.0.16",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.9.1"
+			}
+		},
+		"node_modules/npm/node_modules/fs-minipass": {
+			"version": "3.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/glob": {
+			"version": "13.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/hosted-git-info": {
+			"version": "9.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/http-cache-semantics": {
+			"version": "4.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/npm/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/npm/node_modules/ignore-walk": {
+			"version": "8.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minimatch": "^10.0.3"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/ini": {
+			"version": "6.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/init-package-json": {
+			"version": "8.2.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/package-json": "^7.0.0",
+				"npm-package-arg": "^13.0.0",
+				"promzard": "^3.0.1",
+				"read": "^5.0.1",
+				"semver": "^7.7.2",
+				"validate-npm-package-name": "^7.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/ip-address": {
+			"version": "10.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/npm/node_modules/is-cidr": {
+			"version": "6.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"cidr-regex": "^5.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/npm/node_modules/isexe": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/npm/node_modules/json-parse-even-better-errors": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/json-stringify-nice": {
+			"version": "1.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/jsonparse": {
+			"version": "1.3.1",
+			"dev": true,
+			"engines": [
+				"node >= 0.2.0"
+			],
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/just-diff": {
+			"version": "6.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/just-diff-apply": {
+			"version": "5.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/libnpmaccess": {
+			"version": "10.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-package-arg": "^13.0.0",
+				"npm-registry-fetch": "^19.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmdiff": {
+			"version": "8.1.12",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^9.9.1",
+				"@npmcli/installed-package-contents": "^4.0.0",
+				"binary-extensions": "^3.0.0",
+				"diff": "^8.0.2",
+				"minimatch": "^10.0.3",
+				"npm-package-arg": "^13.0.0",
+				"pacote": "^21.0.2",
+				"tar": "^7.5.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmexec": {
+			"version": "10.3.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/arborist": "^9.9.1",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"ci-info": "^4.0.0",
+				"npm-package-arg": "^13.0.0",
+				"pacote": "^21.0.2",
+				"proc-log": "^6.0.0",
+				"read": "^5.0.1",
+				"semver": "^7.3.7",
+				"signal-exit": "^4.1.0",
+				"walk-up-path": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmfund": {
+			"version": "7.0.26",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^9.9.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmorg": {
+			"version": "8.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^19.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmpack": {
+			"version": "9.1.13",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^9.9.1",
+				"@npmcli/run-script": "^10.0.0",
+				"npm-package-arg": "^13.0.0",
+				"pacote": "^21.0.2"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmpublish": {
+			"version": "11.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/package-json": "^7.0.0",
+				"ci-info": "^4.0.0",
+				"npm-package-arg": "^13.0.0",
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.7",
+				"sigstore": "^4.0.0",
+				"ssri": "^13.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmsearch": {
+			"version": "9.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-registry-fetch": "^19.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmteam": {
+			"version": "8.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^19.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmversion": {
+			"version": "8.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^7.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.7"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/lru-cache": {
+			"version": "11.5.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/npm/node_modules/make-fetch-happen": {
+			"version": "15.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/agent": "^4.0.0",
+				"@npmcli/redact": "^4.0.0",
+				"cacache": "^20.0.1",
+				"http-cache-semantics": "^4.1.1",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^5.0.0",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"negotiator": "^1.0.0",
+				"proc-log": "^6.0.0",
+				"ssri": "^13.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/minimatch": {
+			"version": "10.2.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/minipass": {
+			"version": "7.1.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-collect": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-fetch": {
+			"version": "5.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.0.3",
+				"minipass-sized": "^2.0.0",
+				"minizlib": "^3.0.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			},
+			"optionalDependencies": {
+				"iconv-lite": "^0.7.2"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-flush": {
+			"version": "1.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minipass": "^7.1.3"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-pipeline": {
+			"version": "1.2.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+			"version": "3.3.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/minipass-sized": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minizlib": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/npm/node_modules/ms": {
+			"version": "2.1.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/mute-stream": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/negotiator": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp": {
+			"version": "12.4.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"env-paths": "^2.2.0",
+				"exponential-backoff": "^3.1.1",
+				"graceful-fs": "^4.2.6",
+				"nopt": "^9.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.5",
+				"tar": "^7.5.4",
+				"tinyglobby": "^0.2.12",
+				"undici": "^6.25.0",
+				"which": "^6.0.0"
+			},
+			"bin": {
+				"node-gyp": "bin/node-gyp.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/nopt": {
+			"version": "9.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"abbrev": "^4.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-audit-report": {
+			"version": "7.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-bundled": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-normalize-package-bin": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-install-checks": {
+			"version": "8.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"semver": "^7.1.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-normalize-package-bin": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-package-arg": {
+			"version": "13.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"hosted-git-info": "^9.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-name": "^7.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-packlist": {
+			"version": "10.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"ignore-walk": "^8.0.0",
+				"proc-log": "^6.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-pick-manifest": {
+			"version": "11.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-install-checks": "^8.0.0",
+				"npm-normalize-package-bin": "^5.0.0",
+				"npm-package-arg": "^13.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-profile": {
+			"version": "12.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^6.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-registry-fetch": {
+			"version": "19.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/redact": "^4.0.0",
+				"jsonparse": "^1.3.1",
+				"make-fetch-happen": "^15.0.0",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^5.0.0",
+				"minizlib": "^3.0.1",
+				"npm-package-arg": "^13.0.0",
+				"proc-log": "^6.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-user-validate": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/p-map": {
+			"version": "7.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/pacote": {
+			"version": "21.5.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/git": "^7.0.0",
+				"@npmcli/installed-package-contents": "^4.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"cacache": "^20.0.0",
+				"fs-minipass": "^3.0.0",
+				"minipass": "^7.0.2",
+				"npm-package-arg": "^13.0.0",
+				"npm-packlist": "^10.0.1",
+				"npm-pick-manifest": "^11.0.1",
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^6.0.0",
+				"sigstore": "^4.0.0",
+				"ssri": "^13.0.0",
+				"tar": "^7.4.3"
+			},
+			"bin": {
+				"pacote": "bin/index.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/parse-conflict-json": {
+			"version": "5.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"json-parse-even-better-errors": "^5.0.0",
+				"just-diff": "^6.0.0",
+				"just-diff-apply": "^5.2.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/postcss-selector-parser": {
+			"version": "7.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npm/node_modules/proc-log": {
+			"version": "6.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/proggy": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/promise-all-reject-late": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/promise-call-limit": {
+			"version": "3.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/promzard": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"read": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/qrcode-terminal": {
+			"version": "0.12.0",
+			"dev": true,
+			"inBundle": true,
+			"bin": {
+				"qrcode-terminal": "bin/qrcode-terminal.js"
+			}
+		},
+		"node_modules/npm/node_modules/read": {
+			"version": "5.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"mute-stream": "^3.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/read-cmd-shim": {
+			"version": "6.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/npm/node_modules/semver": {
+			"version": "7.8.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/sigstore": {
+			"version": "4.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^4.0.0",
+				"@sigstore/core": "^3.2.1",
+				"@sigstore/protobuf-specs": "^0.5.0",
+				"@sigstore/sign": "^4.1.1",
+				"@sigstore/tuf": "^4.0.2",
+				"@sigstore/verify": "^3.1.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/socks": {
+			"version": "2.8.9",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.1.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/socks-proxy-agent": {
+			"version": "8.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-exceptions": {
+			"version": "2.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "CC-BY-3.0"
+		},
+		"node_modules/npm/node_modules/spdx-expression-parse": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-license-ids": {
+			"version": "3.0.23",
+			"dev": true,
+			"inBundle": true,
+			"license": "CC0-1.0"
+		},
+		"node_modules/npm/node_modules/ssri": {
+			"version": "13.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/supports-color": {
+			"version": "10.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/tar": {
+			"version": "7.5.22",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/npm/node_modules/text-table": {
+			"version": "0.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/tiny-relative-date": {
+			"version": "2.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/npm/node_modules/treeverse": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/tuf-js": {
+			"version": "4.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tufjs/models": "4.1.0",
+				"debug": "^4.4.3",
+				"make-fetch-happen": "^15.0.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/undici": {
+			"version": "6.28.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
+			}
+		},
+		"node_modules/npm/node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/validate-npm-package-name": {
+			"version": "7.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/walk-up-path": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/npm/node_modules/which": {
+			"version": "6.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^4.0.0"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/write-file-atomic": {
+			"version": "7.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/yallist": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/nth-check": {
@@ -11599,16 +10519,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/on-finished": {
@@ -11828,10 +10738,10 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/pend": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+		"node_modules/phoenix": {
+			"version": "1.8.13",
+			"resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.8.13.tgz",
+			"integrity": "sha512-5UByH7ejdsPLd6eihwzV3L3i6YX4mHUtFjLaE8S1YuA+3aBj37rzH6KDjxBuPlB04o9ZHVz+PKRiUg3aYYvzmQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -11848,39 +10758,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/pinkie": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/pinkie-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pinkie": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/pkce-challenge": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -11889,16 +10766,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/possible-typed-array-names": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/powershell-utils": {
@@ -11940,12 +10807,29 @@
 				"node": ">= 0.9.0"
 			}
 		},
-		"node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+		"node_modules/protobufjs": {
+			"version": "7.6.6",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+			"integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
 			"dev": true,
-			"license": "MIT"
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
@@ -12086,29 +10970,6 @@
 				"react": "^18.3.1"
 			}
 		},
-		"node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/readable-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -12166,24 +11027,6 @@
 			"engines": {
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/roarr": {
-			"version": "2.15.4",
-			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-			"integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"boolean": "^3.0.1",
-				"detect-node": "^2.0.4",
-				"globalthis": "^1.0.1",
-				"json-stringify-safe": "^5.0.1",
-				"semver-compare": "^1.0.0",
-				"sprintf-js": "^1.1.2"
-			},
-			"engines": {
-				"node": ">=8.0"
 			}
 		},
 		"node_modules/router": {
@@ -12298,20 +11141,6 @@
 				"loose-envify": "^1.1.0"
 			}
 		},
-		"node_modules/seek-bzip": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
-			"integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"commander": "^2.8.1"
-			},
-			"bin": {
-				"seek-bunzip": "bin/seek-bunzip",
-				"seek-table": "bin/seek-bzip-table"
-			}
-		},
 		"node_modules/semver": {
 			"version": "7.8.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -12324,13 +11153,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/semver-compare": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/send": {
 			"version": "1.2.1",
@@ -12359,22 +11181,6 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/serialize-error": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.13.1"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/serve-static": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
@@ -12393,24 +11199,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/set-function-length": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"define-data-property": "^1.1.4",
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2",
-				"get-intrinsic": "^1.2.4",
-				"gopd": "^1.0.1",
-				"has-property-descriptors": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/setprototypeof": {
@@ -12454,26 +11242,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/shellcheck": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/shellcheck/-/shellcheck-4.1.0.tgz",
-			"integrity": "sha512-8143z6YGO4+Puwp9Ghn/g7+QxllSKlXaZSm3HXfvQXUfRXhM5P8TPORRHBBlyobl9BnniVne+d1Ff6RgNiccsQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@felipecrs/decompress-tarxz": "5.0.4",
-				"@xhmikosr/decompress-unzip": "7.1.0",
-				"decompress": "4.2.1",
-				"envalid": "8.1.0",
-				"global-agent": "3.0.0"
-			},
-			"bin": {
-				"shellcheck": "bin/shellcheck.js"
-			},
-			"engines": {
-				"node": ">=20.9.0"
 			}
 		},
 		"node_modules/side-channel": {
@@ -12622,9 +11390,9 @@
 			}
 		},
 		"node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -12691,23 +11459,6 @@
 				"text-decoder": "^1.1.0"
 			}
 		},
-		"node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/string_decoder/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -12772,16 +11523,6 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
-		"node_modules/strip-dirs": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-			"integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-natural-number": "^4.0.1"
-			}
-		},
 		"node_modules/strip-final-newline": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
@@ -12793,23 +11534,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/strtok3": {
-			"version": "10.3.5",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
-			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tokenizer/token": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/supports-color": {
@@ -12829,9 +11553,9 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.5.19",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-			"integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+			"version": "7.5.22",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+			"integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -12933,27 +11657,15 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/to-buffer": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
-			"integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+		"node_modules/tmp": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+			"integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"isarray": "^2.0.5",
-				"safe-buffer": "^5.2.1",
-				"typed-array-buffer": "^1.0.3"
-			},
 			"engines": {
-				"node": ">= 0.4"
+				"node": ">=14.14"
 			}
-		},
-		"node_modules/to-buffer/node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -12976,25 +11688,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.6"
-			}
-		},
-		"node_modules/token-types": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
-			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@borewit/text-codec": "^0.2.1",
-				"@tokenizer/token": "^0.3.0",
-				"ieee754": "^1.2.1"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/tsheredoc": {
@@ -13041,19 +11734,6 @@
 			"dev": true,
 			"license": "Unlicense"
 		},
-		"node_modules/type-fest": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/type-is": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
@@ -13087,51 +11767,12 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/typed-array-buffer": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"es-errors": "^1.3.0",
-				"is-typed-array": "^1.1.14"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/uc.micro": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
 			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/uint8array-extras": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/unbzip2-stream": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"buffer": "^5.2.1",
-				"through": "^2.3.8"
-			}
 		},
 		"node_modules/undici": {
 			"version": "7.29.0",
@@ -13142,6 +11783,13 @@
 			"engines": {
 				"node": ">=20.18.1"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/unicorn-magic": {
 			"version": "0.4.0",
@@ -13231,28 +11879,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/which-typed-array": {
-			"version": "1.1.22",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
-			"integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.9",
-				"call-bound": "^1.0.4",
-				"for-each": "^0.3.5",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"has-tostringtag": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/widest-line": {
@@ -13375,26 +12001,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.4"
-			}
-		},
-		"node_modules/xz-decompress": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/xz-decompress/-/xz-decompress-0.2.3.tgz",
-			"integrity": "sha512-O8v6HG8T0PrKBcpyWA13GkSYWFvncwzuzcLx5A7++l3HsE3atmoetXjIxrZ/JV/nbvSZ7WS4+3XvREZuVn+rEA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/yallist": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -13439,19 +12045,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/yauzl": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
-			"integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pend": "~1.2.0"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/yoctocolors": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,21 @@
 		"check:md": "bash scripts/lint-md.sh",
 		"check:yaml": "yamllint -s .",
 		"worktree:init": "bash scripts/worktree-init.sh",
-		"check:actions": "bash scripts/check-actions.sh"
+		"check:actions": "bash scripts/check-actions.sh",
+		"gate": "FLEET_DOC_FAST=0 bash .git-hooks/pre-commit"
 	},
 	"devDependencies": {
 		"github-actionlint": "^1.7.12",
 		"heroku": "^11.10.0",
-		"markdownlint-cli2": "0.23.2",
-		"shellcheck": "^4.1.0"
+		"markdownlint-cli2": "0.23.2"
+	},
+	"overrides": {
+		"adm-zip": "0.6.0"
+	},
+	"allowScripts": {
+		"cpu-features@0.0.10": true,
+		"protobufjs@7.6.6": true,
+		"ssh2@1.17.0": true,
+		"yarn@1.22.22": true
 	}
 }

--- a/scripts/check-actions.sh
+++ b/scripts/check-actions.sh
@@ -1,14 +1,9 @@
 #!/usr/bin/env bash
 # Lint GitHub Actions workflows with actionlint + shellcheck.
 #
-# Both tools are lockfile-pinned npm deps (node_modules/.bin). CI and local
-# gates share the same binaries — no mise/brew/PATH dependence, no sourcing
-# ~/code/dotagents (gate-lib is for local hooks only; scripts CI runs must be
-# repo-self-contained — see rules/dependency-grounding.md).
-#
-# The `shellcheck` npm package lazily downloads the official koalaman binary
-# on first invoke; warm it here so actionlint's -shellcheck path is a real
-# executable before the lint runs.
+# actionlint comes from the npm lockfile. ShellCheck's official release archive
+# is pinned by version and SHA-256 below; verify it before extraction/execution.
+# The verified archive is cached inside node_modules for local/CI parity.
 #
 # Copy into each workflow repo as scripts/check-actions.sh, then:
 #   "check:actions": "bash scripts/check-actions.sh"
@@ -20,18 +15,46 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 ACTIONLINT="$ROOT/node_modules/.bin/github-actionlint"
-SHELLCHECK="$ROOT/node_modules/.bin/shellcheck"
+SHELLCHECK_VERSION=v0.11.0
 
 if [[ ! -x "$ACTIONLINT" ]]; then
 	echo "✗ github-actionlint not found at $ACTIONLINT — run npm ci" >&2
 	exit 1
 fi
-if [[ ! -x "$SHELLCHECK" ]]; then
-	echo "✗ shellcheck not found at $SHELLCHECK — run npm ci" >&2
-	exit 1
+case "$(uname -s):$(uname -m)" in
+  Darwin:arm64) platform=darwin.aarch64; digest=339b930feb1ea764467013cc1f72d09cd6b869ebf1013296ba9055ab2ffbd26f ;;
+  Darwin:x86_64) platform=darwin.x86_64; digest=c2c15e08df0e8fbc374c335b230a7ee958c313fa5714817a59aa59f1aa594f51 ;;
+  Linux:aarch64|Linux:arm64) platform=linux.aarch64; digest=68a8133197a50beb8803f8d42f9908d1af1c5540d4bb05fdfca8c1fa47decefc ;;
+  Linux:x86_64) platform=linux.x86_64; digest=b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6 ;;
+  *) echo "Unsupported ShellCheck platform: $(uname -s) $(uname -m)" >&2; exit 1 ;;
+esac
+cache="$ROOT/node_modules/.cache/shellcheck/$SHELLCHECK_VERSION/$platform"
+mkdir -p "$cache"
+archive="$cache/release.tar.gz"
+work="$(mktemp -d "$cache/run.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+if [[ ! -f "$archive" ]]; then
+  curl --fail --location --silent --show-error \
+    "https://github.com/koalaman/shellcheck/releases/download/$SHELLCHECK_VERSION/shellcheck-$SHELLCHECK_VERSION.$platform.tar.gz" \
+    --output "$work/download.tar.gz"
+  archive="$work/download.tar.gz"
 fi
+actual="$(shasum -a 256 "$archive")"
+if [[ "${actual%% *}" != "$digest" ]]; then
+  echo "ShellCheck archive checksum mismatch: $archive (remove it and retry)" >&2
+  exit 1
+fi
+if [[ "$archive" == "$work/download.tar.gz" ]]; then
+  mv "$archive" "$cache/release.tar.gz"
+  archive="$cache/release.tar.gz"
+fi
+tar -xzf "$archive" -C "$work"
+SHELLCHECK="$work/shellcheck-$SHELLCHECK_VERSION/shellcheck"
 
-# Warm the lazy-downloaded binary (prints version; fails loud on network/arch miss).
-"$SHELLCHECK" --version >/dev/null
-
-exec "$ACTIONLINT" -shellcheck "$SHELLCHECK" .github/workflows/*.yml
+# github-actionlint 1.7.x bundles pre-v3.1 create-github-app-token metadata (no
+# client-id; app-id still required). Workflows retain app-id alongside client-id.
+# Drop this -ignore flag when actionlint's popular-actions registry catches up
+# (rhysd/actionlint#652 / #668).
+"$ACTIONLINT" -shellcheck "$SHELLCHECK" \
+	-ignore 'input "client-id" is not defined in action "actions/create-github-app-token@' \
+	.github/workflows/*.yml

--- a/scripts/check-python-pins.py
+++ b/scripts/check-python-pins.py
@@ -1,0 +1,39 @@
+"""Fail when the active Python environment differs from this repo's exact pins."""
+
+import re
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+def check_pins(root):
+    errors = []
+    wanted_python = (root / ".python-version").read_text().strip()
+    running_python = ".".join(map(str, sys.version_info[:2]))
+    if wanted_python != running_python:
+        errors.append(f"Python {running_python} is active; expected {wanted_python}")
+    for number, line in enumerate((root / "requirements.txt").read_text().splitlines(), 1):
+        requirement = line.split("#", 1)[0].strip()
+        if not requirement:
+            continue
+        match = re.fullmatch(r"([A-Za-z0-9._-]+)(?:\[[A-Za-z0-9_,.-]+\])?==([A-Za-z0-9.+!-]+)", requirement)
+        if not match:
+            errors.append(f"requirements.txt:{number}: unsupported non-exact pin {requirement!r}")
+            continue
+        package, wanted = match.groups()
+        try:
+            installed = version(package)
+        except PackageNotFoundError:
+            installed = "missing"
+        if installed != wanted:
+            errors.append(f"{package}: installed {installed}, expected {wanted}")
+    return errors
+
+
+if __name__ == "__main__":
+    failures = check_pins(Path(__file__).resolve().parents[1])
+    if failures:
+        print("Python dependency drift: " + "; ".join(failures), file=sys.stderr)
+        print("Activate the repo .venv and run python -m pip install -r requirements.txt.", file=sys.stderr)
+        sys.exit(1)
+    print("Python runtime and installed requirements match repo pins")

--- a/tests/test_python_pins.py
+++ b/tests/test_python_pins.py
@@ -1,0 +1,30 @@
+"""The gate must reject stale environments even when requirements files match."""
+
+import runpy
+import sys
+from pathlib import Path
+
+check_pins = runpy.run_path(str(Path(__file__).resolve().parents[1] / "scripts/check-python-pins.py"))["check_pins"]
+
+
+def test_installed_metadata_must_match_the_requirement(tmp_path, monkeypatch):
+    (tmp_path / ".python-version").write_text(".".join(map(str, sys.version_info[:2])))
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("fleet-gate-fixture==1.0 # pinned fixture\n")
+    metadata = tmp_path / "fleet_gate_fixture-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text("Name: fleet-gate-fixture\nVersion: 1.0\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    assert check_pins(tmp_path) == []
+    requirements.write_text("fleet-gate-fixture==2.0\n")
+    assert check_pins(tmp_path) == ["fleet-gate-fixture: installed 1.0, expected 2.0"]
+
+
+def test_missing_packages_runtime_drift_and_unsupported_pins_fail(tmp_path):
+    (tmp_path / ".python-version").write_text("0.0")
+    (tmp_path / "requirements.txt").write_text("fleet-nonexistent-fixture==1.0\nDjango>=6\n")
+    failures = check_pins(tmp_path)
+    assert len(failures) == 3
+    assert "expected 0.0" in failures[0]
+    assert "installed missing" in failures[1]
+    assert "unsupported non-exact pin" in failures[2]


### PR DESCRIPTION
Use the canonical checksum-verified Actions helper and run the complete shared manual gate even with an empty index. Remove the unused ShellCheck npm wrapper and apply compatible dependency fixes with exact reviewed install-script approvals.

Verify the active Python minor and installed requirements before tests, including when borrowing the main checkout venv; matching requirements files alone did not detect a stale environment. Check dependency compatibility with pip check.

Validation: full local gate in an isolated fresh pinned Python environment, two regression tests for runtime/package drift, and independent full ship review. Existing production x-release-id wiring remains owned by the separately claimed release-header task.
