### PR TITLE
fix: expose Heroku build identity on production responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Production URL: <https://www.blogthedata.com>
 
 Deployment: `heroku-github` (Heroku app `blogthedata`, auto-deployed from GitHub `main`)
 
+Production responses expose `x-release-id` from Heroku's `HEROKU_BUILD_COMMIT`. Enable the app's `runtime-dyno-metadata` and `runtime-dyno-build-metadata` labs flags for this value. Missing or invalid metadata produces `dev`, which fails `/ship` verification. Require the header to resolve to the merge commit or a descendant; HTTP 200 or a successful build alone is insufficient.
+
 ## Stack
 
 Django 6.1 blogging platform on Python 3.14. SQLite by default, Postgres optional. HTMX for partial updates, CKEditor 5 for authoring, OpenAI for chatbot/title generation. WhiteNoise + optional S3/CloudFront for static/media. Deploys via Procfile (Heroku-style).

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,4 +1,22 @@
+import os
+import re
+
 from django.http import HttpResponsePermanentRedirect
+
+
+class ReleaseIdMiddleware:
+    """Expose Heroku's build identity, including redirects and error responses."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        commit = os.environ.get("HEROKU_BUILD_COMMIT", "")
+        # Local or unconfigured runtimes must never look like a verified release.
+        self.release_id = commit if re.fullmatch(r"[0-9a-f]{40}", commit) else "dev"
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response["x-release-id"] = self.release_id
+        return response
 
 
 class WwwRedirectMiddleware:
@@ -18,4 +36,4 @@ class WwwRedirectMiddleware:
             return HttpResponsePermanentRedirect(
                 f"{request.scheme}://www.{host}{request.get_full_path()}"
             )
-        return self.get_response(request) 
+        return self.get_response(request)

--- a/app/settings.py
+++ b/app/settings.py
@@ -187,6 +187,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "app.middleware.ReleaseIdMiddleware",
     'django.middleware.gzip.GZipMiddleware',
     'htmlmin.middleware.HtmlMinifyMiddleware',
     'htmlmin.middleware.MarkRequestMiddleware',

--- a/tests/test_release_identity.py
+++ b/tests/test_release_identity.py
@@ -1,0 +1,35 @@
+import os
+from unittest.mock import patch
+
+from django.test import Client, override_settings
+
+from .base import SetUp
+
+
+@override_settings(ALLOWED_HOSTS=["www.blogthedata.com", "blogthedata.com"])
+class ProductionReleaseIdentityTests(SetUp):
+    def test_deployed_build_is_identifiable_on_pages_redirects_and_errors(self):
+        commit = "0326f35a191e07e60372ec8f2769e5b3cb3dd0a6"
+        with patch.dict(os.environ, {"HEROKU_BUILD_COMMIT": commit}):
+            client = Client()
+            page = client.get("/", HTTP_HOST="www.blogthedata.com", secure=True)
+            redirect = client.get("/", HTTP_HOST="blogthedata.com", secure=True)
+            missing = client.get(
+                "/missing-release-probe/", HTTP_HOST="www.blogthedata.com", secure=True
+            )
+        self.assertEqual(page.status_code, 200)
+        self.assertEqual(redirect.status_code, 301)
+        self.assertEqual(missing.status_code, 404)
+        for response in (page, redirect, missing):
+            self.assertEqual(response["x-release-id"], commit)
+
+    def test_unconfigured_or_invalid_build_identity_cannot_pass_release_verification(self):
+        for commit in (None, "dev", "0326f35-dirty", "release\r\nInjected: header"):
+            with self.subTest(commit=commit), patch.dict(os.environ):
+                if commit is None:
+                    os.environ.pop("HEROKU_BUILD_COMMIT", None)
+                else:
+                    os.environ["HEROKU_BUILD_COMMIT"] = commit
+                response = Client().get("/", HTTP_HOST="www.blogthedata.com", secure=True)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response["x-release-id"], "dev")


### PR DESCRIPTION
Production deployment verification cannot identify the running blog revision because responses lack `x-release-id`. Add first-position middleware that returns the validated Heroku `HEROKU_BUILD_COMMIT` on pages, redirects, and errors. Missing or malformed metadata returns `dev`, making incomplete deployment setup visible to the ship verifier.

Document the required Heroku dyno metadata flags and cover normal, redirect, 404, missing, malformed, and header-injection scenarios. Validation: full local `npm run gate` (including pytest/coverage, Python pins/compatibility, Ruff, YAML, and actionlint) passed; light ship review is clean. Both required Heroku metadata flags were enabled and verified before the merge-triggered deployment. After merge, verify the normal GitHub-main Heroku release plus the live header against the merge SHA.
