### PR TITLE
fix(seo): prepare image dimensions and encode share links

### DIFF
--- a/blog/image_dimensions.py
+++ b/blog/image_dimensions.py
@@ -1,0 +1,16 @@
+"""Known intrinsic image dimensions used by post cards.
+
+The default post image is a static asset whose dimensions are stable. Uploaded
+post images are recorded on ``Post`` after the resized file has been written so
+request rendering never has to inspect storage.
+"""
+
+DEFAULT_METAIMG_WIDTH = 1207
+DEFAULT_METAIMG_HEIGHT = 1392
+
+DEFAULT_METAIMG_DIMENSIONS = (DEFAULT_METAIMG_WIDTH, DEFAULT_METAIMG_HEIGHT)
+
+
+def is_default_metaimg(name):
+    """Return whether ``name`` is the model's unuploaded default value."""
+    return name == "default.webp"

--- a/blog/management/commands/backfill_post_image_dimensions.py
+++ b/blog/management/commands/backfill_post_image_dimensions.py
@@ -1,0 +1,156 @@
+from dataclasses import dataclass
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import DEFAULT_DB_ALIAS, connections, transaction
+from PIL import Image, UnidentifiedImageError
+
+from blog.image_dimensions import DEFAULT_METAIMG_DIMENSIONS, is_default_metaimg
+from blog.models import Post
+
+
+@dataclass(frozen=True)
+class ImageRow:
+    pk: int
+    slug: str | None
+    name: str
+    width: int | None
+    height: int | None
+
+
+class Command(BaseCommand):
+    help = (
+        "Populate Post.metaimg_width/metaimg_height from the stored, resized "
+        "post images. Run after migration 0045 and before the consumer release. "
+        "Missing media or concurrent image changes fail the command."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--database",
+            default=DEFAULT_DB_ALIAS,
+            help=f"Database to use (default: {DEFAULT_DB_ALIAS}).",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Recompute dimensions for every post instead of only missing rows.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Read and validate dimensions without writing the database.",
+        )
+
+    def handle(self, *args, **options):
+        database_alias = options["database"]
+        connection = connections[database_alias]
+        rows = self._load_rows(connection, force=options["force"])
+        validated = []
+        missing = []
+
+        # Read and validate every object before opening a transaction or issuing
+        # an UPDATE.  A bad object therefore cannot leave a partially-filled
+        # dimensions table behind.
+        for row in rows:
+            try:
+                width, height = self._dimensions_for(row.name)
+            except (OSError, ValueError, UnidentifiedImageError) as exc:
+                missing.append(
+                    f"pk={row.pk} slug={row.slug!r} image={row.name!r}: {exc}"
+                )
+                continue
+
+            validated.append((row, width, height))
+
+        if missing:
+            preview = "; ".join(missing[:10])
+            if len(missing) > 10:
+                preview += f"; … and {len(missing) - 10} more"
+            raise CommandError(
+                f"Could not read dimensions for {len(missing)} post image(s): "
+                f"{preview}"
+            )
+
+        if options["dry_run"]:
+            self.stdout.write(f"Validated {len(validated)} post image dimension row(s).")
+            return
+
+        updated = self._write_rows(connection, database_alias, validated)
+        self.stdout.write(f"Updated {updated} post image dimension row(s).")
+
+    @staticmethod
+    def _load_rows(connection, *, force):
+        """Read only columns present before the consumer model release.
+
+        This command intentionally does not use ``metaimg_width`` or
+        ``metaimg_height`` as Django model fields.  The schema-only release
+        runs it while the application still has the old ``Post`` model.
+        """
+
+        meta = Post._meta
+        table = connection.ops.quote_name(meta.db_table)
+        pk_column = connection.ops.quote_name(meta.pk.column)
+        slug_column = connection.ops.quote_name(meta.get_field("slug").column)
+        image_column = connection.ops.quote_name(meta.get_field("metaimg").column)
+        width_column = connection.ops.quote_name("metaimg_width")
+        height_column = connection.ops.quote_name("metaimg_height")
+        where = ""
+        if not force:
+            where = f"WHERE {width_column} IS NULL OR {height_column} IS NULL"
+
+        query = (
+            f"SELECT {pk_column}, {slug_column}, {image_column}, "
+            f"{width_column}, {height_column} FROM {table} {where} "
+            f"ORDER BY {pk_column}"
+        )
+        with connection.cursor() as cursor:
+            cursor.execute(query)
+            return [ImageRow(*row) for row in cursor.fetchall()]
+
+    @staticmethod
+    def _dimensions_for(name):
+        if not name:
+            raise ValueError("post has no image name")
+        # Only the exact database default is trusted.  A custom upload called
+        # ``default.webp`` is stored below ``post_metaimgs/`` and is inspected.
+        if is_default_metaimg(name):
+            return DEFAULT_METAIMG_DIMENSIONS
+
+        storage = Post._meta.get_field("metaimg").storage
+        with storage.open(name, "rb") as image_file:
+            with Image.open(image_file) as image:
+                width, height = image.size
+                image.verify()
+
+        if not width or not height:
+            raise ValueError("stored image has no intrinsic dimensions")
+        return width, height
+
+    @staticmethod
+    def _write_rows(connection, database_alias, validated):
+        if not validated:
+            return 0
+
+        meta = Post._meta
+        table = connection.ops.quote_name(meta.db_table)
+        pk_column = connection.ops.quote_name(meta.pk.column)
+        image_column = connection.ops.quote_name(meta.get_field("metaimg").column)
+        width_column = connection.ops.quote_name("metaimg_width")
+        height_column = connection.ops.quote_name("metaimg_height")
+        query = (
+            f"UPDATE {table} SET {width_column} = %s, {height_column} = %s "
+            f"WHERE {pk_column} = %s AND {image_column} = %s"
+        )
+
+        with transaction.atomic(using=database_alias):
+            with connection.cursor() as cursor:
+                for row, width, height in validated:
+                    cursor.execute(query, (width, height, row.pk, row.name))
+                    if cursor.rowcount != 1:
+                        raise CommandError(
+                            "Post image changed while dimensions were being "
+                            f"backfilled (pk={row.pk}, image={row.name!r}); "
+                            "rerun the command."
+                        )
+
+        return len(validated)

--- a/blog/migrations/0045_post_metaimg_dimensions.py
+++ b/blog/migrations/0045_post_metaimg_dimensions.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("blog", "0044_alter_post_metaimg"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.AddField(
+                    model_name="post",
+                    name="metaimg_height",
+                    field=models.PositiveIntegerField(blank=True, null=True),
+                ),
+                migrations.AddField(
+                    model_name="post",
+                    name="metaimg_width",
+                    field=models.PositiveIntegerField(blank=True, null=True),
+                ),
+            ],
+            state_operations=[],
+        ),
+    ]

--- a/blog/templates/blog/post/post_detail.html
+++ b/blog/templates/blog/post/post_detail.html
@@ -130,7 +130,7 @@
   <ul class="social-share">
     <li>
       <a class="resp-sharing-button__link x"
-        href="https://twitter.com/intent/tweet/?text={{ post.title }}&amp;url={{ request.build_absolute_uri }}"
+        href="https://twitter.com/intent/tweet/?text={{ post.title|urlencode:'' }}&amp;url={{ request.build_absolute_uri|urlencode:'' }}"
         target="_blank" rel="noopener noreferrer" aria-label="Share on X">
         <div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
           <img class="social-share-btn" src="{% static 'svg/x-share-btn.svg' %}" alt="X">
@@ -140,7 +140,7 @@
     </li>
     <li>
       <a class="resp-sharing-button__link reddit"
-        href="https://reddit.com/submit/?url={{ request.build_absolute_uri }}&amp;resubmit=true&amp;title={{ post.title }}"
+        href="https://reddit.com/submit/?url={{ request.build_absolute_uri|urlencode:'' }}&amp;resubmit=true&amp;title={{ post.title|urlencode:'' }}"
         target="_blank" rel="noopener" aria-label="Share on Reddit">
         <div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solidcircle">
           <img class="social-share-btn" src="{% static 'svg/reddit-share-btn.svg' %}" alt="Reddit">
@@ -150,7 +150,7 @@
     </li>
     <li>
       <a class="resp-sharing-button__link linkedin"
-        href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ request.build_absolute_uri }}&amp;title={{ post.title }}&amp;summary={{ post.metadesc }}&amp;source={{ request.build_absolute_uri }}"
+        href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ request.build_absolute_uri|urlencode:'' }}&amp;title={{ post.title|urlencode:'' }}&amp;summary={{ post.metadesc|default_if_none:''|urlencode:'' }}&amp;source={{ request.build_absolute_uri|urlencode:'' }}"
         target="_blank" rel="noopener" aria-label="Share on LinkedIn">
         <div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solidcircle">
           <img class="social-share-btn" src="{% static 'svg/linkedin-share-btn.svg' %}" alt="LinkedIn">

--- a/blog/templatetags/image_utils.py
+++ b/blog/templatetags/image_utils.py
@@ -4,6 +4,8 @@ from django.utils.safestring import mark_safe
 import re
 import logging
 
+from blog.image_dimensions import DEFAULT_METAIMG_DIMENSIONS, is_default_metaimg
+
 logger = logging.getLogger(__name__)
 register = template.Library()
 
@@ -63,18 +65,14 @@ def get_image_url(image_field):
         return f"/mediafiles/{image_field.name}"
 
 
-# Intrinsic size of static/default.webp (Post.metaimg default) — avoid opening storage.
-_DEFAULT_METAIMG_WH = (1207, 1392)
-
-
 @register.simple_tag
 def image_dimension_attrs(image_field, default_width=1200, default_height=630):
     """Return safe width=/height= attributes for CLS without 500ing on missing media."""
     if not image_field:
         return ""
     name = getattr(image_field, "name", "") or ""
-    if name.endswith("default.webp"):
-        w, h = _DEFAULT_METAIMG_WH
+    if is_default_metaimg(name):
+        w, h = DEFAULT_METAIMG_DIMENSIONS
         return mark_safe(f'width="{w}" height="{h}"')
     try:
         w, h = image_field.width, image_field.height

--- a/tests/test_post_image_backfill.py
+++ b/tests/test_post_image_backfill.py
@@ -1,0 +1,151 @@
+from importlib import import_module
+from io import BytesIO
+from types import SimpleNamespace
+
+from blog.templatetags.image_utils import image_dimension_attrs
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.management import CommandError, call_command
+from django.db import connection, migrations
+from PIL import Image
+
+from .base import SetUp
+from .utils import create_unique_post
+
+
+def image_upload(name, size):
+    image_data = BytesIO()
+    Image.new("RGB", size).save(image_data, format="PNG")
+    return SimpleUploadedFile(
+        name=name,
+        content=image_data.getvalue(),
+        content_type="image/png",
+    )
+
+
+def dimensions_for(post_id):
+    table = connection.ops.quote_name("blog_post")
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"SELECT metaimg_width, metaimg_height FROM {table} WHERE id = %s",
+            [post_id],
+        )
+        return cursor.fetchone()
+
+
+class PostImageBackfillTests(SetUp):
+    def test_schema_migration_only_adds_nullable_columns(self):
+        migration = import_module(
+            "blog.migrations.0045_post_metaimg_dimensions"
+        ).Migration
+        database_operations = migration.operations[0].database_operations
+
+        self.assertEqual(migration.operations[0].state_operations, [])
+        self.assertTrue(all(operation.field.null for operation in database_operations))
+        self.assertTrue(
+            all(isinstance(operation, migrations.AddField) for operation in database_operations)
+        )
+        self.assertEqual(
+            {operation.name for operation in database_operations},
+            {"metaimg_width", "metaimg_height"},
+        )
+
+    def test_template_uses_actual_dimensions_for_custom_default_filename(self):
+        image = SimpleNamespace(
+            name="post_metaimgs/default.webp", width=1920, height=640,
+            instance=SimpleNamespace(metaimg_width=1920, metaimg_height=640),
+        )
+        self.assertEqual(image_dimension_attrs(image), 'width="1920" height="640"')
+        self.assertEqual(
+            image_dimension_attrs(SimpleNamespace(name="default.webp")),
+            'width="1207" height="1392"',
+        )
+
+    def test_backfill_populates_default_dimensions_without_storage_read(self):
+        post = create_unique_post()
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE blog_post SET metaimg_width = NULL, metaimg_height = NULL "
+                "WHERE id = %s",
+                [post.pk],
+            )
+        self.assertIsNone(dimensions_for(post.pk)[0])
+
+        call_command("backfill_post_image_dimensions")
+
+        self.assertEqual(dimensions_for(post.pk), (1207, 1392))
+
+    def test_backfill_validates_every_image_before_writing_any_row(self):
+        valid_post = create_unique_post()
+        valid_post.metaimg = image_upload("backfill-valid.png", (3000, 1000))
+        valid_post.save()
+        image_storage = valid_post._meta.get_field("metaimg").storage
+        valid_name = valid_post.metaimg.name
+        self.addCleanup(lambda: image_storage.delete(valid_name))
+
+        missing_post = create_unique_post()
+        table = connection.ops.quote_name("blog_post")
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"UPDATE {table} SET metaimg_width = NULL, metaimg_height = NULL "
+                "WHERE id IN (%s, %s)",
+                [valid_post.pk, missing_post.pk],
+            )
+            cursor.execute(
+                f"UPDATE {table} SET metaimg = %s WHERE id = %s",
+                ["post_metaimgs/does-not-exist.webp", missing_post.pk],
+            )
+
+        with self.assertRaises(CommandError):
+            call_command("backfill_post_image_dimensions")
+
+        self.assertEqual(dimensions_for(valid_post.pk), (None, None))
+        self.assertEqual(dimensions_for(missing_post.pk), (None, None))
+
+    def test_backfill_does_not_treat_custom_default_named_upload_as_static(self):
+        post = create_unique_post()
+        post.metaimg = image_upload("default.webp", (3000, 1000))
+        post.save()
+        image_storage = post._meta.get_field("metaimg").storage
+        image_name = post.metaimg.name
+        self.addCleanup(lambda: image_storage.delete(image_name))
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE blog_post SET metaimg_width = NULL, metaimg_height = NULL "
+                "WHERE id = %s",
+                [post.pk],
+            )
+
+        call_command("backfill_post_image_dimensions")
+
+        self.assertEqual(dimensions_for(post.pk), (1920, 640))
+
+    def test_backfill_rejects_an_image_changed_after_validation(self):
+        post = create_unique_post()
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE blog_post SET metaimg_width = NULL, metaimg_height = NULL "
+                "WHERE id = %s",
+                [post.pk],
+            )
+        command = import_module(
+            "blog.management.commands.backfill_post_image_dimensions"
+        ).Command()
+        rows = command._load_rows(connection, force=False)
+        validated = [
+            (row, *command._dimensions_for(row.name))
+            for row in rows
+            if row.pk == post.pk
+        ]
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE blog_post SET metaimg = %s WHERE id = %s",
+                ["post_metaimgs/changed.webp", post.pk],
+            )
+
+        with self.assertRaises(CommandError):
+            command._write_rows(connection, "default", validated)
+
+        self.assertEqual(dimensions_for(post.pk), (None, None))

--- a/tests/test_seo_meta.py
+++ b/tests/test_seo_meta.py
@@ -1,5 +1,7 @@
 import json
 import re
+from html import unescape
+from urllib.parse import parse_qs, urlsplit
 
 from django.templatetags.static import static
 
@@ -24,6 +26,29 @@ def _meta_content(html, attr, value):
 class SeoMetaTests(SetUp):
     """Locks in the SEO head fixes: clean canonical, un-prefixed social image,
     a single canonical on /all-posts/, and valid JSON-LD on post pages."""
+
+    def test_share_links_preserve_reserved_characters_in_query_values(self):
+        self.first_post.title = "100% faster & safer? C++ / Python #1 | café"
+        self.first_post.metadesc = "A&B + 50% = progress #today"
+        self.first_post.save()
+        path = self.first_post.get_absolute_url() + "?from=a%26b&mode=one"
+        html = self.client.get(path).content.decode()
+        expected_url = f"http://testserver{path}"
+        for label, title_key in (("X", "text"), ("Reddit", "title"), ("LinkedIn", "title")):
+            with self.subTest(service=label):
+                tag = next(
+                    tag for tag in re.findall(r"<a\b[^>]*>", html)
+                    if f'aria-label="Share on {label}"' in tag
+                )
+                href = unescape(re.search(r'href="([^"]+)"', tag).group(1))
+                url = urlsplit(href)
+                query = parse_qs(url.query)
+                self.assertEqual(query[title_key], [self.first_post.title])
+                self.assertEqual(query["url"], [expected_url])
+                self.assertEqual(url.fragment, "")
+                if label == "LinkedIn":
+                    self.assertEqual(query["summary"], [self.first_post.metadesc])
+                    self.assertEqual(query["source"], [expected_url])
 
     def test_csp_allows_cloudflare_web_analytics_beacon(self):
         # Auto-injected CF Insights beacon is blocked without these hosts


### PR DESCRIPTION
The archive currently opens each post image in remote storage to discover dimensions, contributing to an 8.2-second render. This first rollout adds nullable image-dimension columns without exposing them to the running model, plus a backfill command that validates every image before an atomic, image-name-guarded update. Runtime consumers will be shipped only after the deployed schema and backfill are verified.

It also fixes X, Reddit, and LinkedIn share links by encoding each query value, preserving titles and descriptions containing `%`, `&`, `+`, `#`, slashes, and Unicode.

Validation: full local repository gate passed (87% coverage); backfill tests cover missing-media rollback and concurrent image changes; desktop/mobile browser smoke exercised the share controls with reserved-character fixtures and a clean final console.

Rollout after this PR reaches main: verify the Heroku release identity, run migration 0045 through a one-off dyno, run the backfill, and confirm zero missing dimensions before the consumer release. Procfile remains unchanged. No production image storage or schema change occurs merely by deploying this stage.
