### PR TITLE
perf(blog): eliminate archive image reads and repeated queries

### DIFF
--- a/blog/migrations/0046_post_metaimg_dimensions_state.py
+++ b/blog/migrations/0046_post_metaimg_dimensions_state.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("blog", "0045_post_metaimg_dimensions"),
+    ]
+
+    operations = [
+        # 0045 creates and backfills the columns while the old model is still
+        # safe to run.  This state-only step makes them available to the
+        # consumer model in the following release without touching the DB.
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="post",
+                    name="metaimg_height",
+                    field=models.PositiveIntegerField(
+                        blank=True, editable=False, null=True
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="post",
+                    name="metaimg_width",
+                    field=models.PositiveIntegerField(
+                        blank=True, editable=False, null=True
+                    ),
+                ),
+            ],
+            database_operations=[],
+        ),
+    ]

--- a/blog/models.py
+++ b/blog/models.py
@@ -1,13 +1,43 @@
-from django.db import models
+import logging
+
+from django.contrib.auth.models import User
+from django.db import models, transaction
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.text import slugify
-from django.contrib.auth.models import User
 from django_ckeditor_5.fields import CKEditor5Field
 from django_resized import ResizedImageField
+from django_resized.forms import ResizedImageFieldFile
+
+from .post_image_lifecycle import (
+    ImageCleanupState,
+    apply_dimension_state,
+    build_image_save_plan,
+    read_resized_dimensions,
+)
 
 # import logging
 # logger = logging.getLogger("django")
+logger = logging.getLogger(__name__)
+
+
+class _PostMetaimgFieldFile(ResizedImageFieldFile):
+    """Mark direct FieldFile.save() calls before they save the model."""
+
+    def save(self, name, content, save=True):
+        self.instance._metaimg_direct_save_pending = True
+        try:
+            result = super().save(name, content, save=save)
+            cleanup_state = getattr(self.instance, "_metaimg_cleanup_state", None)
+            if cleanup_state is not None:
+                cleanup_state.record(self.name)
+            return result
+        except Exception:
+            cleanup_state = getattr(self.instance, "_metaimg_cleanup_state", None)
+            if cleanup_state is not None and self._committed:
+                cleanup_state.record(self.name)
+            self.instance._metaimg_direct_save_pending = False
+            raise
 
 
 def slugify_instance(instance, save=False, new_slug=None):
@@ -66,6 +96,16 @@ class Post(models.Model):
         upload_to="post_metaimgs",
         default="default.webp",
     )
+    # Persist the dimensions of the resized file.  Reading ImageField.width or
+    # .height for an S3-backed field opens the object, which is too expensive
+    # to do once per card on the archive.  These stay nullable until the
+    # explicit backfill command has inspected legacy media.
+    metaimg_width = models.PositiveIntegerField(
+        null=True, blank=True, editable=False
+    )
+    metaimg_height = models.PositiveIntegerField(
+        null=True, blank=True, editable=False
+    )
     metaimg_alt_txt = models.CharField(max_length=500, default="John Solly Headshot")
     metaimg_attribution = models.CharField(max_length=500, blank=True, null=True)
     content = CKEditor5Field(blank=True, null=True)
@@ -75,6 +115,22 @@ class Post(models.Model):
     author = models.ForeignKey(User, on_delete=models.CASCADE)
 
     objects = PostManager()  # Make sure objects only include active (not draft) posts.
+
+    @classmethod
+    def from_db(cls, db, field_names, values, *, fetch_mode=None):
+        instance = super().from_db(db, field_names, values, fetch_mode=fetch_mode)
+        if "metaimg" in field_names:
+            instance._metaimg_saved_name = instance.metaimg.name
+        return instance
+
+    def refresh_from_db(self, using=None, fields=None, from_queryset=None):
+        super().refresh_from_db(using=using, fields=fields, from_queryset=from_queryset)
+        # A partial refresh can leave an assigned deferred image in the
+        # instance dictionary even though the database did not refresh it.
+        # Only advance the persisted-image baseline when this refresh actually
+        # included the image field (or was a full refresh).
+        if fields is None or "metaimg" in fields:
+            self._metaimg_saved_name = self.metaimg.name
 
     def get_related_posts(self) -> models.QuerySet:
         """
@@ -93,16 +149,124 @@ class Post(models.Model):
     def get_absolute_url(self):
         return reverse("post-detail", kwargs={"slug": self.slug})
 
+    def _ensure_metaimg_baseline(self, database_alias):
+        if (
+            not hasattr(self, "_metaimg_saved_name")
+            and self.pk is not None
+            and not self._state.adding
+        ):
+            # A deferred field can be assigned a committed path without ever
+            # loading its old value. Establish the DB baseline before deciding
+            # whether dimensions need to be refreshed.
+            self._metaimg_saved_name = (
+                self.__class__._base_manager.using(database_alias)
+                .filter(pk=self.pk)
+                .values_list("metaimg", flat=True)
+                .first()
+                or ""
+            )
+
+    def _delete_owned_image(self, image_name):
+        if not image_name:
+            return
+        try:
+            self.metaimg.storage.delete(image_name)
+        except Exception:
+            logger.exception(
+                "Unable to clean up post image after dimension failure",
+                extra={"metaimg_name": image_name},
+            )
+
+    def _save_uploaded_image(self, args, kwargs, plan, database_alias):
+        cleanup_state = ImageCleanupState(
+            persisted_name=plan.persisted_name,
+            owns_new_storage_object=plan.owns_new_storage_object,
+        )
+        # Register cleanup before Model.save() so a post_save exception cannot
+        # strand a file written by FileField.pre_save().
+        self._metaimg_cleanup_state = cleanup_state
+        try:
+            with transaction.atomic(using=database_alias):
+                super().save(*args, **kwargs)
+                saved_image = self.metaimg
+                cleanup_state.record(saved_image.name)
+                width, height = read_resized_dimensions(saved_image)
+                self.metaimg_width = width
+                self.metaimg_height = height
+                # Keep this bookkeeping update out of Model.save()/post_save
+                # so an image upload does not trigger similarity computation
+                # twice. The image-name predicate prevents a stale upload
+                # from writing dimensions over a concurrent change.
+                updated = (
+                    self.__class__._base_manager.using(database_alias)
+                    .filter(pk=self.pk, metaimg=saved_image.name)
+                    .update(metaimg_width=width, metaimg_height=height)
+                )
+                if updated != 1:
+                    raise ValueError(
+                        "Post image changed while dimensions were being saved "
+                        f"(pk={self.pk}, image={saved_image.name!r})"
+                    )
+        except Exception:
+            saved_image = self.__dict__.get("metaimg")
+            if getattr(saved_image, "_committed", False):
+                cleanup_state.record(saved_image.name)
+            self._delete_owned_image(cleanup_state.name)
+            raise
+        finally:
+            if getattr(self, "_metaimg_cleanup_state", None) is cleanup_state:
+                del self._metaimg_cleanup_state
+
     def save(self, *args, **kwargs):
         if not self.slug:
             slugify_instance(self, save=False)
 
-        super().save(*args, **kwargs)
+        update_fields = kwargs.get("update_fields")
+        update_fields_set = set(update_fields) if update_fields is not None else None
+        image_is_deferred = "metaimg" in self.get_deferred_fields()
+        if image_is_deferred and (
+            update_fields_set is None or "metaimg" not in update_fields_set
+        ):
+            # Django saves only loaded fields for a deferred instance when
+            # update_fields is omitted. Do not fetch the image merely to
+            # compare it, and do not advance its baseline marker.
+            super().save(*args, **kwargs)
+            return
+
+        database_alias = self._state.db or "default"
+        self._ensure_metaimg_baseline(database_alias)
+        plan = build_image_save_plan(self, update_fields)
+        if plan.effective_update_fields is not None:
+            kwargs["update_fields"] = set(plan.effective_update_fields)
+        apply_dimension_state(self, plan)
+
+        original_state_db = self._state.db
+        was_adding = self._state.adding
+        try:
+            if plan.image_was_uploaded:
+                self._save_uploaded_image(args, kwargs, plan, database_alias)
+            else:
+                super().save(*args, **kwargs)
+        except Exception:
+            if was_adding and self.pk is not None:
+                self.pk = None
+                self._state.adding = True
+                self._state.db = original_state_db
+            raise
+
+        if plan.image_was_persisted:
+            self._metaimg_saved_name = self.metaimg.name
+            self._metaimg_direct_save_pending = False
 
     def get_metaimg_url(self):
         if self.metaimg:
             return self.metaimg.url
         return None
+
+
+# Keep the migration field class unchanged while marking direct file saves for
+# the lifecycle bookkeeping above.
+Post._meta.get_field("metaimg").attr_class = _PostMetaimgFieldFile
 
 
 class Similarity(models.Model):

--- a/blog/post_image_lifecycle.py
+++ b/blog/post_image_lifecycle.py
@@ -1,0 +1,141 @@
+from dataclasses import dataclass
+
+from .image_dimensions import DEFAULT_METAIMG_DIMENSIONS, is_default_metaimg
+
+_DIMENSION_FIELDS = frozenset({"metaimg_width", "metaimg_height"})
+
+
+@dataclass(frozen=True)
+class ImageSavePlan:
+    """Decisions made before persisting a Post image change."""
+
+    image_name: str
+    persisted_name: str
+    update_fields: frozenset[str] | None
+    effective_update_fields: frozenset[str] | None
+    image_was_uploaded: bool
+    image_was_cleared: bool
+    default_dimensions_need_refresh: bool
+    image_was_persisted: bool
+    owns_new_storage_object: bool
+
+
+@dataclass
+class ImageCleanupState:
+    """Track a newly written storage path while the DB save is in flight."""
+
+    persisted_name: str
+    owns_new_storage_object: bool
+    name: str | None = None
+
+    def record(self, image_name):
+        candidate = owned_image_name(
+            self.persisted_name, self.owns_new_storage_object, image_name
+        )
+        if candidate:
+            self.name = candidate
+
+
+def build_image_save_plan(post, update_fields):
+    """Describe image and dimension work for one ``Post.save()`` call."""
+    update_fields_set = frozenset(update_fields) if update_fields is not None else None
+    image_field = post.metaimg
+    image_name = image_field.name if image_field else ""
+    persisted_name = getattr(post, "_metaimg_saved_name", "") or ""
+    image_name_changed = (
+        hasattr(post, "_metaimg_saved_name") and persisted_name != image_name
+    )
+    image_had_pending_content = bool(image_field and not image_field._committed)
+    direct_fieldfile_save_pending = bool(
+        getattr(post, "_metaimg_direct_save_pending", False)
+    )
+    image_was_uploaded = bool(image_field) and (
+        image_name_changed
+        or image_had_pending_content
+        or direct_fieldfile_save_pending
+        or (
+            post._state.adding
+            and bool(image_field)
+            and not is_default_metaimg(image_name)
+        )
+    )
+    if image_was_uploaded and update_fields_set is not None:
+        image_was_uploaded = "metaimg" in update_fields_set
+
+    image_was_persisted = update_fields_set is None or "metaimg" in update_fields_set
+    image_was_cleared = (
+        image_was_persisted
+        and not image_field
+        and (post.metaimg_width is not None or post.metaimg_height is not None)
+    )
+
+    default_dimensions_need_refresh = (
+        image_was_persisted
+        and bool(image_field)
+        and is_default_metaimg(image_name)
+        and (post.metaimg_width, post.metaimg_height) != DEFAULT_METAIMG_DIMENSIONS
+    )
+
+    # Assigning the database default path is a replacement with a known static
+    # file. A pending upload named ``default.webp`` is measured after resizing.
+    default_path_assignment = (
+        image_name_changed
+        and bool(image_field)
+        and not image_had_pending_content
+        and is_default_metaimg(image_name)
+    )
+    if default_path_assignment and image_was_persisted:
+        image_was_uploaded = False
+        default_dimensions_need_refresh = True
+
+    dimensions_need_write = (
+        image_was_uploaded or image_was_cleared or default_dimensions_need_refresh
+    )
+    effective_update_fields = update_fields_set
+    if dimensions_need_write and effective_update_fields is not None:
+        effective_update_fields |= _DIMENSION_FIELDS
+
+    return ImageSavePlan(
+        image_name=image_name,
+        persisted_name=persisted_name,
+        update_fields=update_fields_set,
+        effective_update_fields=effective_update_fields,
+        image_was_uploaded=image_was_uploaded,
+        image_was_cleared=image_was_cleared,
+        default_dimensions_need_refresh=default_dimensions_need_refresh,
+        image_was_persisted=image_was_persisted,
+        owns_new_storage_object=(
+            image_had_pending_content or direct_fieldfile_save_pending
+        ),
+    )
+
+
+def apply_dimension_state(post, plan):
+    """Prepare persisted dimensions before the model save."""
+    if plan.image_was_uploaded or plan.image_was_cleared:
+        post.metaimg_width = None
+        post.metaimg_height = None
+    elif plan.default_dimensions_need_refresh:
+        post.metaimg_width, post.metaimg_height = DEFAULT_METAIMG_DIMENSIONS
+
+
+def read_resized_dimensions(image_field):
+    """Read dimensions from the stored, transformed image exactly once."""
+    image_field._file = None
+    image_field.__dict__.pop("_dimensions_cache", None)
+    try:
+        width, height = image_field.width, image_field.height
+        if not width or not height or width <= 0 or height <= 0:
+            raise ValueError("stored image has no positive intrinsic dimensions")
+        return width, height
+    except (OSError, ValueError) as exc:
+        raise ValueError(
+            f"Unable to read dimensions for saved post image {image_field.name!r}"
+        ) from exc
+
+
+def owned_image_name(persisted_name, owns_new_storage_object, image_name):
+    """Return an uploaded path safe to delete after a failed save."""
+    if owns_new_storage_object and image_name and image_name != persisted_name:
+        return image_name
+    return None

--- a/blog/templates/blog/parts/post_card.html
+++ b/blog/templates/blog/parts/post_card.html
@@ -43,7 +43,7 @@
           </div>
           <div class="comment-details">
             <img src="{% static 'svg/comment-icon.svg' %}" alt="" class="comment-icon" width="20" height="24">
-            <p>{{ post.comments.count }}</p>
+            <p>{{ post|comment_count }}</p>
           </div>
         </div>
       </div>

--- a/blog/templates/blog/post/post_detail.html
+++ b/blog/templates/blog/post/post_detail.html
@@ -33,8 +33,10 @@
 <meta property="article:published_time" content="{{ post.date_posted|date:'c' }}">
 <meta property="og:image" content="{{ metaimg_url }}">
 <meta name="twitter:image" content="{{ metaimg_url }}">
+{% if metaimg_width and metaimg_height %}
 <meta property="og:image:width" content="{{ metaimg_width }}">
 <meta property="og:image:height" content="{{ metaimg_height }}">
+{% endif %}
 <meta property="og:image:alt" content="{{ post.metaimg_alt_txt }}">
 
 <!-- Structured data -->

--- a/blog/templatetags/image_utils.py
+++ b/blog/templatetags/image_utils.py
@@ -1,8 +1,9 @@
+import logging
+import re
+
 from django import template
 from django.conf import settings
 from django.utils.safestring import mark_safe
-import re
-import logging
 
 from blog.image_dimensions import DEFAULT_METAIMG_DIMENSIONS, is_default_metaimg
 
@@ -66,19 +67,32 @@ def get_image_url(image_field):
 
 
 @register.simple_tag
-def image_dimension_attrs(image_field, default_width=1200, default_height=630):
-    """Return safe width=/height= attributes for CLS without 500ing on missing media."""
+def image_dimension_attrs(image_field):
+    """Return persisted intrinsic dimensions without opening image storage.
+
+    Uploaded post images have their dimensions recorded on ``Post`` after the
+    resized file is saved.  Legacy rows are populated by the explicit
+    ``backfill_post_image_dimensions`` command.  The default image is a known
+    static asset and can be handled without a storage read even before that
+    backfill has run.
+    """
     if not image_field:
         return ""
+
+    post = getattr(image_field, "instance", None)
+    width = getattr(post, "metaimg_width", None)
+    height = getattr(post, "metaimg_height", None)
+    if width and height:
+        return mark_safe(f'width="{width}" height="{height}"')
+
     name = getattr(image_field, "name", "") or ""
     if is_default_metaimg(name):
         w, h = DEFAULT_METAIMG_DIMENSIONS
         return mark_safe(f'width="{w}" height="{h}"')
-    try:
-        w, h = image_field.width, image_field.height
-    except (ValueError, OSError) as exc:
-        logger.warning("image dimensions unavailable; using defaults (%s)", exc)
-        return mark_safe(f'width="{default_width}" height="{default_height}"')
-    if w and h:
-        return mark_safe(f'width="{w}" height="{h}"')
-    return mark_safe(f'width="{default_width}" height="{default_height}"')
+
+    logger.error(
+        "post image dimensions are missing; run backfill_post_image_dimensions "
+        "before serving this image (%s)",
+        name,
+    )
+    return ""

--- a/blog/templatetags/post_utils.py
+++ b/blog/templatetags/post_utils.py
@@ -1,6 +1,7 @@
-from django import template
-import readtime
 import html
+
+import readtime
+from django import template
 
 register = template.Library()
 
@@ -14,3 +15,12 @@ def read(input_html):
 
 
 register.filter("readtime", read)
+
+
+@register.filter
+def comment_count(post):
+    """Use the archive annotation when present, then preserve other cards."""
+    annotated_count = getattr(post, "card_comment_count", None)
+    if annotated_count is not None:
+        return annotated_count
+    return post.comments.count()

--- a/blog/utils.py
+++ b/blog/utils.py
@@ -126,8 +126,16 @@ def getPostChunks(post: Post, chunk_size: int = 1800) -> list:
 
 
 def compute_similarity(post_id: int) -> None:
-    post = Post.objects.get(id=post_id)
-    other_posts = Post.objects.exclude(id=post_id).exclude(content="")
+    # Keep this projection limited to fields that existed before the image
+    # dimension migration.  The 0043 data migration calls this function while
+    # the current model may already contain additive columns that are not in
+    # the database yet.
+    post = Post.objects.only("id", "title", "content").get(id=post_id)
+    other_posts = (
+        Post.objects.only("id", "content")
+        .exclude(id=post_id)
+        .exclude(content="")
+    )
 
     if not other_posts.exists():
         return
@@ -168,7 +176,7 @@ def compute_similarity(post_id: int) -> None:
         )
         Similarity.objects.update_or_create(
             post1=post,
-            post2=Post.objects.get(pk=pk),
+            post2=Post.objects.only("id").get(pk=pk),
             defaults={
                 "score": cosine_sim[0][idx - 1]
             },  # Adjust index for cosine_sim offset

--- a/blog/views.py
+++ b/blog/views.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin, LoginRequiredMixin
 from django.contrib.postgres.search import SearchVector, SearchQuery, SearchRank
 from django.db import connection
-from django.db.models import Q
+from django.db.models import Count, Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
@@ -35,6 +35,7 @@ from .forms import PostForm, CommentForm
 from .utils import answer_question
 from .gemini import generate_text
 from users.models import User
+from .image_dimensions import DEFAULT_METAIMG_DIMENSIONS, is_default_metaimg
 
 
 ez_logger = logging.getLogger("ezra_logger")
@@ -149,7 +150,11 @@ class AllPostsView(ListView):
     context_object_name = "posts"  # The default is object_list
 
     def get_queryset(self):
-        return Post.objects.active()
+        return (
+            Post.objects.active()
+            .select_related("category")
+            .annotate(card_comment_count=Count("comments"))
+        )
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
@@ -284,26 +289,35 @@ class PostDetailView(DetailView):
         context["related_posts"] = related_posts
 
         if self.object.metaimg:
-            try:
-                context["metaimg_url"] = self.object.metaimg.url
-                context["metaimg_width"] = self.object.metaimg.width
-                context["metaimg_height"] = self.object.metaimg.height
-            except (ValueError, OSError) as exc:
-                ez_logger.warning(
-                    "Post meta image unavailable; using defaults",
+            context["metaimg_url"] = self.object.metaimg.url
+            metaimg_dimensions = (
+                self.object.metaimg_width,
+                self.object.metaimg_height,
+            )
+            if not all(metaimg_dimensions) and is_default_metaimg(
+                self.object.metaimg.name
+            ):
+                metaimg_dimensions = DEFAULT_METAIMG_DIMENSIONS
+
+            if all(metaimg_dimensions):
+                context["metaimg_width"], context["metaimg_height"] = (
+                    metaimg_dimensions
+                )
+            else:
+                ez_logger.error(
+                    "Post meta image dimensions are missing; run "
+                    "backfill_post_image_dimensions before serving this image",
                     extra={
                         "post_slug": self.object.slug,
                         "metaimg_name": self.object.metaimg.name,
-                        "error": str(exc),
                     },
                 )
-                context["metaimg_url"] = ""
-                context["metaimg_width"] = 1200
-                context["metaimg_height"] = 630
+                context["metaimg_width"] = ""
+                context["metaimg_height"] = ""
         else:
             context["metaimg_url"] = ""
-            context["metaimg_width"] = 1200
-            context["metaimg_height"] = 630
+            context["metaimg_width"] = ""
+            context["metaimg_height"] = ""
 
         return context
 

--- a/tests/test_archive_performance.py
+++ b/tests/test_archive_performance.py
@@ -1,0 +1,408 @@
+from html.parser import HTMLParser
+from io import BytesIO
+from unittest.mock import patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from PIL import Image
+
+from .base import SetUp
+from .utils import create_unique_post
+
+from blog.image_dimensions import DEFAULT_METAIMG_DIMENSIONS
+from blog.models import Post
+
+
+def image_upload(name, size):
+    image_data = BytesIO()
+    Image.new("RGB", size).save(image_data, format="PNG")
+    return SimpleUploadedFile(
+        name=name,
+        content=image_data.getvalue(),
+        content_type="image/png",
+    )
+
+
+class MetaPropertyParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.properties = {}
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "meta":
+            return
+        attributes = dict(attrs)
+        property_name = attributes.get("property")
+        if property_name:
+            self.properties[property_name] = attributes.get("content")
+
+
+class ArchivePerformanceTests(SetUp):
+    def test_persisted_dimensions_are_not_author_editable_fields(self):
+        self.assertFalse(Post._meta.get_field("metaimg_width").editable)
+        self.assertFalse(Post._meta.get_field("metaimg_height").editable)
+
+    def test_archive_query_count_is_bounded_and_rendering_never_opens_media(self):
+        create_unique_post()
+
+        def render_archive():
+            with CaptureQueriesContext(connection) as queries:
+                response = self.client.get(reverse("all-posts"))
+            return response, len(queries)
+
+        image_storage = Post._meta.get_field("metaimg").storage
+        with patch.object(
+            image_storage,
+            "open",
+            side_effect=AssertionError("archive rendering opened post media"),
+        ):
+            baseline_response, baseline_queries = render_archive()
+            for _ in range(5):
+                create_unique_post()
+            expanded_response, expanded_queries = render_archive()
+
+        self.assertEqual(baseline_response.status_code, 200)
+        self.assertEqual(expanded_response.status_code, 200)
+        self.assertLessEqual(expanded_queries, baseline_queries + 1)
+        self.assertLessEqual(expanded_queries, 4)
+
+        html = expanded_response.content.decode()
+        for post in Post.objects.filter(draft=False):
+            self.assertIn(f'href="{post.get_absolute_url()}"', html)
+        self.assertNotIn(self.draft_post.get_absolute_url(), html)
+
+    def test_post_detail_uses_persisted_dimensions_without_opening_media(self):
+        post = create_unique_post()
+        image_storage = Post._meta.get_field("metaimg").storage
+
+        with patch.object(
+            image_storage,
+            "open",
+            side_effect=AssertionError("post detail opened post media"),
+        ):
+            response = self.client.get(post.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        meta_properties = MetaPropertyParser()
+        meta_properties.feed(html)
+        self.assertEqual(meta_properties.properties["og:image:width"], "1207")
+        self.assertEqual(meta_properties.properties["og:image:height"], "1392")
+
+    def test_post_detail_omits_missing_custom_dimensions_without_storage_read(self):
+        post = create_unique_post()
+        image_storage = Post._meta.get_field("metaimg").storage
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE blog_post SET metaimg = %s, metaimg_width = NULL, "
+                "metaimg_height = NULL WHERE id = %s",
+                ["post_metaimgs/missing-custom.webp", post.pk],
+            )
+
+        with patch.object(
+            image_storage,
+            "open",
+            side_effect=AssertionError("missing dimensions opened post media"),
+        ):
+            response = self.client.get(post.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        meta_properties = MetaPropertyParser()
+        meta_properties.feed(html)
+        self.assertNotIn("og:image:width", meta_properties.properties)
+        self.assertNotIn("og:image:height", meta_properties.properties)
+        image_start = html.index('id="post-detail-meta-img"')
+        image_end = html.index(">", image_start)
+        self.assertNotIn("width=", html[image_start:image_end])
+
+    def test_uploaded_and_replaced_images_store_resized_dimensions(self):
+        post = create_unique_post()
+        image_storage = Post._meta.get_field("metaimg").storage
+        uploaded_names = []
+        self.addCleanup(lambda: [image_storage.delete(name) for name in uploaded_names])
+
+        post.metaimg = image_upload("archive-wide.png", (3000, 1000))
+        # Form validation can inspect the source image before Model.save().
+        self.assertEqual((post.metaimg.width, post.metaimg.height), (3000, 1000))
+        post.save()
+        self.assertEqual((post.metaimg_width, post.metaimg_height), (1920, 640))
+        uploaded_names.append(post.metaimg.name)
+
+        post.metaimg = image_upload("archive-tall.png", (800, 2000))
+        post.save(update_fields=["metaimg"])
+        post.refresh_from_db()
+        self.assertEqual((post.metaimg_width, post.metaimg_height), (432, 1080))
+        uploaded_names.append(post.metaimg.name)
+
+        # Reassigning an already-stored image still refreshes dimensions; it
+        # must not preserve the dimensions of the previous upload.
+        post.metaimg = uploaded_names[0]
+        post.save(update_fields=["metaimg"])
+        post.refresh_from_db()
+        self.assertEqual((post.metaimg_width, post.metaimg_height), (1920, 640))
+
+        post.metaimg = "default.webp"
+        with patch.object(
+            image_storage,
+            "open",
+            side_effect=AssertionError("default replacement should not read storage"),
+        ):
+            post.save(update_fields=["metaimg"])
+        post.refresh_from_db()
+        self.assertEqual(
+            (post.metaimg_width, post.metaimg_height), DEFAULT_METAIMG_DIMENSIONS
+        )
+
+        post.metaimg = image_upload("default.webp", (3000, 1000))
+        post.save(update_fields=["metaimg"])
+        post.refresh_from_db()
+        self.assertEqual((post.metaimg_width, post.metaimg_height), (1920, 640))
+        uploaded_names.append(post.metaimg.name)
+
+    def test_direct_fieldfile_save_updates_dimensions_on_fresh_instance(self):
+        post = create_unique_post()
+        post = Post.objects.get(pk=post.pk)
+        image_storage = Post._meta.get_field("metaimg").storage
+        image = image_upload("direct-fieldfile.png", (3000, 1000))
+        self.addCleanup(lambda: image_storage.delete(post.metaimg.name))
+
+        post.metaimg.save(image.name, image, save=True)
+        post.refresh_from_db()
+
+        self.assertEqual((post.metaimg_width, post.metaimg_height), (1920, 640))
+
+    def test_direct_fieldfile_save_on_new_post_updates_dimensions(self):
+        image_storage = Post._meta.get_field("metaimg").storage
+        post = Post(
+            title="Direct new fieldfile",
+            category=self.default_category,
+            author=self.admin_user,
+            content="Content",
+            snippet="Snippet",
+        )
+        image = image_upload("direct-new-fieldfile.png", (3000, 1000))
+
+        post.metaimg.save(image.name, image, save=True)
+        image_name = post.metaimg.name
+        self.addCleanup(lambda: image_storage.delete(image_name))
+        post.refresh_from_db()
+
+        self.assertEqual((post.metaimg_width, post.metaimg_height), (1920, 640))
+
+    def test_failed_direct_save_preserves_existing_image_and_cleans_new_file(self):
+        post = Post.objects.get(pk=create_unique_post().pk)
+        image_storage = Post._meta.get_field("metaimg").storage
+        old_name = post.metaimg.name
+        old_dimensions = (post.metaimg_width, post.metaimg_height)
+        image = image_upload("direct-existing-failure.png", (3000, 1000))
+        self.addCleanup(
+            lambda: (
+                image_storage.delete(post.metaimg.name)
+                if post.metaimg.name != old_name
+                else None
+            )
+        )
+
+        with (
+            patch.object(
+                image_storage,
+                "open",
+                side_effect=OSError("dimension read failed"),
+            ),
+            self.assertRaises(ValueError),
+        ):
+            post.metaimg.save(image.name, image, save=True)
+
+        new_name = post.metaimg.name
+        self.assertNotEqual(new_name, old_name)
+        self.assertFalse(image_storage.exists(new_name))
+        persisted = Post.objects.get(pk=post.pk)
+        self.assertEqual(persisted.metaimg.name, old_name)
+        self.assertEqual(
+            (persisted.metaimg_width, persisted.metaimg_height), old_dimensions
+        )
+
+    def test_post_save_failure_cleans_existing_direct_replacement(self):
+        post = Post.objects.get(pk=create_unique_post().pk)
+        image_storage = Post._meta.get_field("metaimg").storage
+        old_name = post.metaimg.name
+        old_dimensions = (post.metaimg_width, post.metaimg_height)
+        image = image_upload("direct-post-save-failure.png", (3000, 1000))
+        self.addCleanup(
+            lambda: (
+                image_storage.delete(post.metaimg.name)
+                if post.metaimg.name != old_name
+                else None
+            )
+        )
+
+        with (
+            patch(
+                "blog.signals.compute_similarity",
+                side_effect=RuntimeError("post-save failure"),
+            ),
+            self.assertRaises(RuntimeError),
+        ):
+            post.metaimg.save(image.name, image, save=True)
+
+        new_name = post.metaimg.name
+        self.assertNotEqual(new_name, old_name)
+        self.assertFalse(image_storage.exists(new_name))
+        persisted = Post.objects.get(pk=post.pk)
+        self.assertEqual(persisted.metaimg.name, old_name)
+        self.assertEqual(
+            (persisted.metaimg_width, persisted.metaimg_height), old_dimensions
+        )
+
+    def test_direct_fieldfile_save_false_then_model_save_updates_dimensions(self):
+        image_storage = Post._meta.get_field("metaimg").storage
+        post = Post(
+            title="Direct deferred fieldfile",
+            category=self.default_category,
+            author=self.admin_user,
+            content="Content",
+            snippet="Snippet",
+        )
+        image = image_upload("direct-save-false.png", (800, 2000))
+
+        post.metaimg.save(image.name, image, save=False)
+        post.save()
+        image_name = post.metaimg.name
+        self.addCleanup(lambda: image_storage.delete(image_name))
+        post.refresh_from_db()
+
+        self.assertEqual((post.metaimg_width, post.metaimg_height), (432, 1080))
+
+    def test_deferred_image_baseline_and_partial_save_do_not_stale_dimensions(self):
+        source = create_unique_post()
+        image_storage = Post._meta.get_field("metaimg").storage
+        source.metaimg = image_upload("deferred-source.png", (3000, 1000))
+        source.save()
+        source_name = source.metaimg.name
+        self.addCleanup(lambda: image_storage.delete(source_name))
+
+        target = create_unique_post()
+        deferred = Post.objects.only(
+            "id", "title", "metaimg_width", "metaimg_height"
+        ).get(pk=target.pk)
+
+        # Saving a deferred instance without update_fields makes Django save
+        # only its loaded columns.  The image remains deferred and its
+        # persisted-name marker must stay absent until the image is saved.
+        deferred.title = "Deferred partial title"
+        deferred.save()
+        self.assertFalse(hasattr(deferred, "_metaimg_saved_name"))
+
+        deferred.metaimg = source_name
+
+        deferred.save(update_fields=["title"])
+        target.refresh_from_db()
+        self.assertEqual(target.metaimg.name, "default.webp")
+        self.assertEqual(
+            (target.metaimg_width, target.metaimg_height), DEFAULT_METAIMG_DIMENSIONS
+        )
+
+        deferred.save()
+        target.refresh_from_db()
+        self.assertEqual(target.metaimg.name, source_name)
+        self.assertEqual((target.metaimg_width, target.metaimg_height), (1920, 640))
+
+    def test_dimension_only_save_does_not_reconcile_unpersisted_image_assignment(self):
+        post = create_unique_post()
+        image_storage = Post._meta.get_field("metaimg").storage
+        post.metaimg = image_upload("dimension-only-source.png", (3000, 1000))
+        post.save()
+        image_name = post.metaimg.name
+        self.addCleanup(lambda: image_storage.delete(image_name))
+        post.refresh_from_db()
+        original_dimensions = (post.metaimg_width, post.metaimg_height)
+
+        post.metaimg = "default.webp"
+        post.save(update_fields=["metaimg_width"])
+        persisted = Post.objects.get(pk=post.pk)
+        self.assertEqual(persisted.metaimg.name, image_name)
+        self.assertEqual(
+            (persisted.metaimg_width, persisted.metaimg_height), original_dimensions
+        )
+
+        post.refresh_from_db()
+        post.metaimg = None
+        post.save(update_fields=["metaimg_width"])
+        persisted.refresh_from_db()
+        self.assertEqual(persisted.metaimg.name, image_name)
+        self.assertEqual(
+            (persisted.metaimg_width, persisted.metaimg_height), original_dimensions
+        )
+
+    def test_failed_dimension_read_rolls_back_new_row_and_cleans_uploaded_file(self):
+        image_storage = Post._meta.get_field("metaimg").storage
+        post = Post(
+            title="Atomic image failure",
+            category=self.default_category,
+            author=self.admin_user,
+            content="Content",
+            snippet="Snippet",
+            metaimg=image_upload("atomic-failure.png", (3000, 1000)),
+        )
+
+        with (
+            patch.object(
+                image_storage,
+                "open",
+                side_effect=OSError("dimension read failed"),
+            ),
+            self.assertRaises(ValueError),
+        ):
+            post.save()
+
+        self.assertIsNone(post.pk)
+        self.assertTrue(post._state.adding)
+        self.assertFalse(Post.objects.filter(title="Atomic image failure").exists())
+        self.assertFalse(image_storage.exists(post.metaimg.name))
+
+    def test_empty_stored_image_dimensions_roll_back_and_clean_upload(self):
+        image_storage = Post._meta.get_field("metaimg").storage
+        post = Post(
+            title="Empty stored image",
+            category=self.default_category,
+            author=self.admin_user,
+            content="Content",
+            snippet="Snippet",
+            metaimg=image_upload("empty-stored-image.png", (640, 320)),
+        )
+        with (
+            patch.object(image_storage, "open", return_value=BytesIO(b"")),
+            self.assertRaises(ValueError),
+        ):
+            post.save()
+
+        self.assertIsNone(post.pk)
+        self.assertFalse(Post.objects.filter(title="Empty stored image").exists())
+        self.assertFalse(image_storage.exists(post.metaimg.name))
+
+    def test_invalid_pending_upload_named_existing_object_does_not_delete_it(self):
+        image_storage = Post._meta.get_field("metaimg").storage
+        post = create_unique_post()
+        post.refresh_from_db()
+        old_name = post.metaimg.name
+        old_dimensions = (post.metaimg_width, post.metaimg_height)
+        self.assertEqual(old_name, "default.webp")
+        self.assertTrue(image_storage.exists(old_name))
+
+        post.metaimg = SimpleUploadedFile(
+            old_name,
+            b"not an image",
+            content_type="image/webp",
+        )
+        with self.assertRaises(OSError):
+            post.save()
+
+        persisted = Post.objects.get(pk=post.pk)
+        self.assertEqual(persisted.metaimg.name, old_name)
+        self.assertEqual(
+            (persisted.metaimg_width, persisted.metaimg_height), old_dimensions
+        )
+        self.assertTrue(image_storage.exists(old_name))

--- a/tests/test_post_image_backfill.py
+++ b/tests/test_post_image_backfill.py
@@ -34,6 +34,21 @@ def dimensions_for(post_id):
 
 
 class PostImageBackfillTests(SetUp):
+    def test_consumer_migration_changes_state_without_database_operations(self):
+        migration = import_module(
+            "blog.migrations.0046_post_metaimg_dimensions_state"
+        ).Migration
+        operation = migration.operations[0]
+        self.assertEqual(operation.database_operations, [])
+        self.assertEqual(
+            {field.name for field in operation.state_operations},
+            {"metaimg_width", "metaimg_height"},
+        )
+        self.assertTrue(
+            all(isinstance(field, migrations.AddField) and field.field.null
+                for field in operation.state_operations)
+        )
+
     def test_schema_migration_only_adds_nullable_columns(self):
         migration = import_module(
             "blog.migrations.0045_post_metaimg_dimensions"
@@ -149,3 +164,25 @@ class PostImageBackfillTests(SetUp):
             command._write_rows(connection, "default", validated)
 
         self.assertEqual(dimensions_for(post.pk), (None, None))
+
+    def test_force_backfill_reconciles_old_runtime_image_replacement(self):
+        post = create_unique_post()
+        call_command("backfill_post_image_dimensions", force=True)
+        original_dimensions = dimensions_for(post.pk)
+        storage = post._meta.get_field("metaimg").storage
+        replacement_name = storage.save(
+            "post_metaimgs/old-runtime-replacement.png",
+            image_upload("replacement.png", (640, 320)),
+        )
+        self.addCleanup(lambda: storage.delete(replacement_name))
+        # The Stage1 model can replace the image without updating new columns.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE blog_post SET metaimg = %s WHERE id = %s",
+                [replacement_name, post.pk],
+            )
+
+        call_command("backfill_post_image_dimensions")
+        self.assertEqual(dimensions_for(post.pk), original_dimensions)
+        call_command("backfill_post_image_dimensions", force=True)
+        self.assertEqual(dimensions_for(post.pk), (640, 320))


### PR DESCRIPTION
The full archive currently reads every post image from remote storage and repeats category/comment queries, producing an 8.2-second render with 216 SQL queries and 108 storage opens in the production profile. Cards and post detail now use persisted image dimensions; the archive fetches categories and comment counts with its post query.

Uploads and replacements record the dimensions of the actual resized image. Media-read failures roll back the row update and clean up newly owned objects when possible. An explicit image-save plan separates decisions from persistence and cleanup. Direct file saves, deferred/partial model saves, post-save failures and invalid-upload cleanup have regression coverage; derived dimensions are not editable in admin. Missing custom dimensions log an error and omit dimension attributes without fetching storage during rendering.

Migration 0046 updates Django's model state only. The additive columns were shipped in PR #634 and applied separately; all 107 production images have now been backfilled and verified against independently measured storage dimensions, with zero missing values.

Validation: full local repository gate passed (156 tests, 89% coverage; nine existing deprecation warnings); local mobile Lighthouse medians across three runs were 94/100/100/100; archive regression checks query growth, post-link coverage, and zero media opens; upload lifecycle and detail metadata tests passed. Chrome desktop/mobile archive and post navigation passed with correct image dimensions and no final console errors or warnings.

After landing: verify Heroku's release identity, apply state migration 0046, force-refresh all dimensions and independently verify current stored images, then measure live archive rendering, sitemap responses, Lighthouse medians, and a fresh Ahrefs crawl.
